### PR TITLE
ETCD validation before chart install.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,14 @@
 
 Portworx is a software defined persistent storage solution designed and purpose built for applications deployed as containers, via container orchestrators such as Kubernetes, Marathon and Swarm. It is a clustered block storage solution and provides a Cloud-Native layer from which containerized stateful applications programmatically consume block, file and object storage services directly through the scheduler.
 
+## Helm Chart for Portworx
+
+Follow these [instructions](/charts/px/README.md) to install Portworx onto your kubernetes cluster using Helm
+
 ## Contributing
 
 The specification and code is licensed under the Apache 2.0 license found in the LICENSE file of this repository.
 
-### Helm Chart for Portworx
-
-Follow these [instructions](/charts/px/README.md) to install Portworx onto your kubernetes cluster using Helm
 
 ## Join us on Slack!
 [![](/doc/media//slack.png)](http://slack.portworx.com)

--- a/charts/px/README.md
+++ b/charts/px/README.md
@@ -87,6 +87,8 @@ helm install --name my-release -f values.yaml ./helm/charts/px
 
 ### Basic troubleshooting
 
+#### Helm install errors with `no available release name found`
+
 ``` 
 helm install --dry-run --debug --set etcdEndPoint=etcd:http://192.168.70.90:2379,clusterName=$(uuid) ./helm/charts/px/
 [debug] Created tunnel using local port: '37304'
@@ -104,6 +106,8 @@ You can verify the tiller logs
 [tiller] 2018/02/07 06:00:13 warning: No available release names found after 5 tries
 [tiller] 2018/02/07 06:00:13 failed install prepare step: no available release name found
 ```
+
+#### Helm install errors with  `Job failed: BackoffLimitExceeded`
 
 ```
 helm install --debug --set dataInterface=eth1,managementInterface=eth1,etcdEndPoint=etcd:http://192.168.70.179:2379,clusterName=$(uuid) ./helm/charts/px/

--- a/charts/px/README.md
+++ b/charts/px/README.md
@@ -63,7 +63,7 @@ The following tables lists the configurable parameters of the Datadog chart and 
 | `dataInterface`   | Name of the interface <ethX>             | `none`                                   |
 | `managementInterface`   | Name of the interface <ethX>             | `none`                                   |
 | `envVars`  | Colon-separated list of environment variables that will be exported to portworx. (example: API_SERVER=http://lighthouse-new.portworx.com:MYENV1=val1:MYENV2=val2) | `none`                                    |
-| `stork`    | Storage Orchestration for Hyperconvergence.     | `true`       |
+| `stork`    | Storage Orchestration Runtime for Hyperconvergence.     | `true`       |
 | `etcd.credentials`  | Username and password for ETCD authentication in the form user:password | `none:none`                                    |
 | `etcd.ca`  | Location of CA file for ETCD authentication. Should be /path/to/server.ca | `none`                                    |
 | `etcd.cert`  | Location of certificate for ETCD authentication. Should be /path/to/server.crt | `none`                                    |
@@ -96,8 +96,8 @@ helm install --dry-run --debug --set etcdEndPoint=etcd:http://192.168.70.90:2379
 
 Error: no available release name found
 ```
-This most likely indicates that Tiller doesnt have the right RBAC permissions.
-Verify the tiller logs 
+This most likely indicates that Tiller doesn't have the right RBAC permissions.
+You can verify the tiller logs 
 ```
 [storage/driver] 2018/02/07 06:00:13 get: failed to get "singing-bison.v1": configmaps "singing-bison.v1" is forbidden: User "system:serviceaccount:kube-system:default" cannot get configmaps in the namespace "kube-system"
 [tiller] 2018/02/07 06:00:13 info: generated name singing-bison is taken. Searching again.

--- a/charts/px/templates/hooks/pre-install/etcd-preinstall-hook.yaml
+++ b/charts/px/templates/hooks/pre-install/etcd-preinstall-hook.yaml
@@ -1,0 +1,26 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  namespace: kube-system
+  name: px-etcd-preinstall-hook
+  labels:
+    heritage: {{.Release.Service | quote }}
+    release: {{.Release.Name | quote }}
+    chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: pre-install-job
+        terminationMessagePath: '/dev/termination-log'    
+        terminationMessagePolicy: 'FallbackToLogsOnError'        
+        imagePullPolicy: Always
+        image: "hrishi/px-etcd-preinstall-hook:v1"
+        command: ['/bin/sh']
+        args: ['/usr/bin/etcdStatus.sh',"{{ .Values.etcdEndPoint }}"]


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Validates the ETCD url endpoint before installing the chart.
This helps ensuring there isnt a misconfigured etcd which is a requirement for Portworx. 
 
**Which issue(s) this PR fixes** (optional)
Closes #13 

**Special notes for your reviewer**:

