### PR TITLE
use filesystemDrives if deploying in IKS

### DIFF
--- a/charts/portworx/README.md
+++ b/charts/portworx/README.md
@@ -25,7 +25,7 @@ If the etcdcluster being used is a secured ETCD (SSL/TLS) then please follow ins
 For eg:
 ```
 git clone https://github.com/portworx/helm.git
-helm install --debug --name my-release --set etcdEndPoint=etcd:http://192.168.70.90:2379,clusterName=$(uuid) ./helm/charts/portworx/
+helm install --debug --name my-release --set etcdEndPoint=etcd:http://192.168.70.90:2379,clusterName=$(uuidgen) ./helm/charts/portworx/
 ```
 
 ## Configuration
@@ -93,7 +93,7 @@ The command removes all the Kubernetes components associated with the chart and 
 #### Helm install errors with `no available release name found`
 
 ```
-helm install --dry-run --debug --set etcdEndPoint=etcd:http://192.168.70.90:2379,clusterName=$(uuid) ./helm/charts/portworx/
+helm install --dry-run --debug --set etcdEndPoint=etcd:http://192.168.70.90:2379,clusterName=$(uuidgen) ./helm/charts/portworx/
 [debug] Created tunnel using local port: '37304'
 [debug] SERVER: "127.0.0.1:37304"
 [debug] Original chart version: ""
@@ -113,7 +113,7 @@ You can verify the tiller logs
 #### Helm install errors with  `Job failed: BackoffLimitExceeded`
 
 ```
-helm install --debug --set dataInterface=eth1,managementInterface=eth1,etcdEndPoint=etcd:http://192.168.70.179:2379,clusterName=$(uuid) ./helm/charts/portworx/
+helm install --debug --set dataInterface=eth1,managementInterface=eth1,etcdEndPoint=etcd:http://192.168.70.179:2379,clusterName=$(uuidgen) ./helm/charts/portworx/
 [debug] Created tunnel using local port: '36389'
 
 [debug] SERVER: "127.0.0.1:36389"
@@ -145,7 +145,7 @@ Ensure the correct etcd URL is set as a parameter to the `helm install` command.
 #### Helm install errors with `Job failed: Deadline exceeded`
 
 ```
-helm install --debug --set dataInterface=eth1,managementInterface=eth1,etcdEndPoint=etcd:http://192.168.20.290:2379,clusterName=$(uuid) ./charts/portworx/
+helm install --debug --set dataInterface=eth1,managementInterface=eth1,etcdEndPoint=etcd:http://192.168.20.290:2379,clusterName=$(uuidgen) ./charts/portworx/
 [debug] Created tunnel using local port: '39771'
 
 [debug] SERVER: "127.0.0.1:39771"

--- a/charts/portworx/templates/portworx-ds.yaml
+++ b/charts/portworx/templates/portworx-ds.yaml
@@ -85,7 +85,7 @@ spec:
               "-f",
                 {{- end }}
               {{- else }}
-                {{- $driveNames := .drives | split ";" }}
+                {{- $driveNames := $drives | split ";" }}
                 {{- range $index, $name := $driveNames }}
               "-s", "{{ $name }}",
                 {{- end -}}

--- a/charts/portworx/templates/portworx-ds.yaml
+++ b/charts/portworx/templates/portworx-ds.yaml
@@ -1,4 +1,5 @@
 {{/* Setting defaults if they are omitted. */}}
+{{- $deployEnvironmentIKS := .Capabilities.KubeVersion.GitVersion | regexMatch "IKS" }}
 {{- $usefileSystemDrive := .Values.usefileSystemDrive | default false }}
 {{- $drives := .Values.drives | default "none" }}
 {{- $usedrivesAndPartitions := .Values.usedrivesAndPartitions | default false }}
@@ -81,6 +82,9 @@ spec:
                 {{- else }}
               "-a",
                 {{- end -}}
+                {{- if and ((eq $usefileSystemDrive false)) (($deployEnvironmentIKS)) }}
+              "-f",
+                {{- end }}
                 {{- if eq $usefileSystemDrive true }}
               "-f",
                 {{- end }}


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Detect if the environment is IKS, and if yes, then use unused drives that have a filesystem on it

**Which issue(s) this PR fixes** (optional)
Closes # https://portworx.atlassian.net/browse/PWX-6569


**Special notes for your reviewer**:

