### PR TITLE
PWX-6783: containerd volume fix

### DIFF
--- a/charts/portworx/templates/portworx-ds.yaml
+++ b/charts/portworx/templates/portworx-ds.yaml
@@ -216,6 +216,8 @@ spec:
           {{- end }}
             - name: dockersock
               mountPath: /var/run/docker.sock
+            - name: containerdsock
+              mountPath: /run/containerd
             - name: etcpwx
               mountPath: /etc/pwx
             - name: cores
@@ -320,11 +322,10 @@ spec:
           {{- end}}
         - name: dockersock
           hostPath:
-          {{- if eq $pksInstall true }}
-            path: /var/vcap/sys/run/docker/docker.sock
-          {{- else }}
-            path: /var/run/docker.sock
-          {{- end}}
+            path: {{if eq $pksInstall true}}/var/vcap/sys/run/docker/docker.sock{{else}}/var/run/docker.sock{{end}}
+        - name: containerdsock
+          hostPath:
+            path: {{if eq $pksInstall true}}/var/vcap/sys/run/containerd{{else}}/run/containerd{{end}}
           {{- if eq $csi true}}
         - name: csi-driver-path
           hostPath:


### PR DESCRIPTION
Required for px-1.7, and CRI/containerd support

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
We forgot to add an additional mount for Portworx 1.7 CRI/containerd support.

**Which issue(s) this PR fixes** (optional)
Closes # PWX-6783

**Special notes for your reviewer**:

