### PR TITLE
Remove creation of portworx namespace 

### DIFF
--- a/charts/portworx/templates/portworx-rbac-config.yaml
+++ b/charts/portworx/templates/portworx-rbac-config.yaml
@@ -44,11 +44,6 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 
 ---
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: portworx
----
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:


### PR DESCRIPTION

**What this PR does / why we need it**:

helm chart install fails if the namespace already exists.
