### PR TITLE
Remove portworx namespace creation and px-role from helm chart

### DIFF
--- a/charts/portworx/templates/portworx-rbac-config.yaml
+++ b/charts/portworx/templates/portworx-rbac-config.yaml
@@ -42,34 +42,3 @@ roleRef:
   kind: ClusterRole
   name: node-get-put-list-role
   apiGroup: rbac.authorization.k8s.io
-
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: portworx
----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: px-role
-  namespace: portworx
-rules:
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["get", "list", "create", "update", "patch"]
----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: px-role-binding
-  namespace: portworx
-subjects:
-- kind: ServiceAccount
-  name: px-account
-  namespace: kube-system
-roleRef:
-  kind: Role
-  name: px-role
-  apiGroup: rbac.authorization.k8s.io
----


### PR DESCRIPTION
**What this PR does / why we need it**:
1. We cannot create portworx namespace in the helm chart, as the helm chart installation fails
    if the namespace already exists.
2. If the `portworx` namespace does not exist we cannot create the px-role for that namespace.

The installation process for PX + IBM Key Protect would be like this

1. Create portworx namespace
2. Create the px-role and the role bindings for a non-existent service account (px-account) -> k8s does not complain on this
3. Create the px-ibm k8s secret
4. Install the helm chart

With this flow, PX when installed will automatically get authenticated with IBM KP.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

