### PR TITLE
fix(portworx-ds): remove :shared

### DIFF
--- a/charts/portworx/templates/portworx-ds.yaml
+++ b/charts/portworx/templates/portworx-ds.yaml
@@ -270,7 +270,7 @@ spec:
               mountPropagation: "Bidirectional"
           {{- else }}
             - name: kubelet
-              mountPath: /var/lib/kubelet:shared
+              mountPath: /var/lib/kubelet
               mountPropagation: "Bidirectional"
           {{- end }}
 


### PR DESCRIPTION
On kubernetes > 1.10 the mountPath with `:shared` renders an `Invalid volume specification`. This rendered the chart unusable on kubernetes > v1.10.

<!--
  Make sure to have done the following:
  [x] Signed off your work as per the DCO.
  [x] Add unit-tests
-->

**What this PR does / why we need it**:
To make it work

**Which issue(s) this PR fixes** (optional)
Closes #74 

**Special notes for your reviewer**:
I won't add my real-name. This is simple enough to get it through like it is right now. I do agree to the DCO.
