### PR TITLE
Fix deployment for optional client-auth for etcd

### DIFF
--- a/charts/portworx/templates/hooks/pre-install/etcd-preinstall-hook.yaml
+++ b/charts/portworx/templates/hooks/pre-install/etcd-preinstall-hook.yaml
@@ -1,7 +1,9 @@
 {{- $customRegistryURL := .Values.customRegistryURL | default "none" }}
 {{- $registrySecret := .Values.registrySecret | default "none" }}
 {{- $etcdCertPath := .Values.etcd.certPath | default "none" }}
-
+{{- $etcdCA := .Values.etcd.ca | default "none" }}
+{{- $etcdCert := .Values.etcd.cert | default "none" }}
+{{- $etcdKey := .Values.etcd.key | default "none" }}
 
 apiVersion: batch/v1
 kind: Job
@@ -56,10 +58,14 @@ spec:
           items:
           - key: ca.pem
             path: ca.pem
+          {{- if ne $etcdCert "none" }}
           - key: client.pem
             path: client.pem
+          {{- end -}}
+          {{- if ne $etcdKey "none" }}
           - key: client-key.pem
             path: client-key.pem
+          {{- end -}}
         {{- else}}
         command: ['/bin/bash']
         args: ['/usr/bin/etcdStatus.sh',"{{ .Values.etcdEndPoint }}"]

--- a/charts/portworx/templates/portworx-ds.yaml
+++ b/charts/portworx/templates/portworx-ds.yaml
@@ -318,10 +318,14 @@ spec:
             items:
             - key: ca.pem
               path: ca.pem
+            {{- if ne $etcdCert "none" }}
             - key: client.pem
               path: client.pem
+            {{- end -}}
+            {{- if ne $etcdKey "none" }}
             - key: client-key.pem
               path: client-key.key
+            {{- end -}}
           {{- end}}
         - name: dockersock
           hostPath:

--- a/docker-images/preinstall-hook/etcdStatus.sh
+++ b/docker-images/preinstall-hook/etcdStatus.sh
@@ -26,10 +26,17 @@ echo "Verifying if the provided etcd url is accessible: $etcdURL"
 #Verify with certs if it is a secured etcd. 
 if [[ ! -z $etcdca ]]
 then
-    echo "Verifying connectivity to secure etcd... The certs need to be at the location $etcdca $etcdcert and $etcdkey"
-    response=$(curl --write-out %{http_code} --silent --output /dev/null --cacert $etcdca --cert $etcdcert --key $etcdkey -L "$etcdURL/version" )
-    echo "Response Code: $response"
-    verifyresponse $response
+    if [[ ! -z $etcdcert ]]
+        echo "Verifying connectivity to secure etcd... The certs need to be at the location $etcdca $etcdcert and $etcdkey"
+        response=$(curl --write-out %{http_code} --silent --output /dev/null --cacert $etcdca --cert $etcdcert --key $etcdkey -L "$etcdURL/version" )
+        echo "Response Code: $response"
+        verifyresponse $response
+    else
+        echo "Verifying connectivity to secure etcd... The ca cert needs to be at the location $etcdca"
+        response=$(curl --write-out %{http_code} --silent --output /dev/null --cacert $etcdca -L "$etcdURL/version" )
+        echo "Response Code: $response"
+        verifyresponse $response
+    fi
 else
     echo "Verifying connectivity to Insecure etcd "
     response=$(curl --write-out %{http_code} --silent --output /dev/null "$etcdURL/version")


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->
Signed off by : @mrshah-at-ibm

**What this PR does / why we need it**:
This PR adds capability to deploy the helm chart with an etcd that has self-signed certs but does not require client auth

**Which issue(s) this PR fixes** (optional)
Closes https://github.com/portworx/helm/issues/71

**Special notes for your reviewer**:

