### PR TITLE
PWX-7940: Change LH Role to a ClusterRole and Binding to a ClusterBinding. Also fix the permissions for stork api's

### DIFF
--- a/charts/portworx/templates/portworx-lighthouse.yaml
+++ b/charts/portworx/templates/portworx-lighthouse.yaml
@@ -5,11 +5,11 @@ metadata:
   name: px-lh-account
   namespace: kube-system
 ---
-kind: Role
+kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-   name: px-lh-role
-   namespace: kube-system
+  name: px-lh-role
+  namespace: kube-system
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
@@ -21,20 +21,20 @@ rules:
     resources: ["nodes", "services"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["stork.libopenstorage.org"]
-    resources: ["clusterpairs"]
-    verbs: ["get", "list", "create", "update", "delete"]  
+    resources: ["clusterpairs","migrations"]
+    verbs: ["get", "list", "create", "update", "delete"]
 ---
-kind: RoleBinding
+kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: px-lh-role-binding
   namespace: kube-system
 subjects:
-- kind: ServiceAccount
-  name: px-lh-account
-  namespace: kube-system
+  - kind: ServiceAccount
+    name: px-lh-account
+    namespace: kube-system
 roleRef:
-  kind: Role
+  kind: ClusterRole
   name: px-lh-role
   apiGroup: rbac.authorization.k8s.io
 ---
@@ -92,6 +92,7 @@ spec:
       - name: px-lighthouse
         image: "{{ template "px.getLighthouseImages" . }}/px-lighthouse:{{ required "A valid lighthouse image version is required" .Values.lighthouseVersion}}"
         imagePullPolicy: Always
+        args: [ "-kubernetes", "true" ]
         ports:
         - containerPort: 80
         - containerPort: 443

--- a/charts/portworx/templates/portworx-lighthouse.yaml
+++ b/charts/portworx/templates/portworx-lighthouse.yaml
@@ -21,7 +21,7 @@ rules:
     resources: ["nodes", "services"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["stork.libopenstorage.org"]
-    resources: ["clusterpairs","migrations"]
+    resources: ["clusterpairs","migrations","groupvolumesnapshots"]
     verbs: ["get", "list", "create", "update", "delete"]
 ---
 kind: ClusterRoleBinding


### PR DESCRIPTION
Signed-off-by: Paul <paul@portworx.com>

**What this PR does / why we need it**:
In 2.0 we added stork-connector and px-central to lighthouse.
This requires the lighthouse pod to be able to list cluster objects.

For this we had to change to a ClusterRole and Binding.

I also added the parameter required to tell lighthouse we're running on kubernetes. 
This is so lighthouse knows it should ask for kubeConfigs so we can do migrations.

**Which issue(s) this PR fixes** (optional)
Closes #PWX-7940

