### PR TITLE
Fix client-key.pem not found error

### DIFF
--- a/charts/portworx/templates/portworx-ds.yaml
+++ b/charts/portworx/templates/portworx-ds.yaml
@@ -324,7 +324,7 @@ spec:
             {{- end -}}
             {{- if ne $etcdKey "none" }}
             - key: client-key.pem
-              path: client-key.key
+              path: client-key.pem
             {{- end -}}
           {{- end}}
         - name: dockersock


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
When using specific etcd certificates, portworx container doesn't found the _client-key.pem_ (specified dynamically as an argument in templates/portworx-ds.yaml) because the file is always mounted as _client-key.key_ :
```
            {{- if ne $etcdKey "none" }}
            - key: client-key.pem
              path: client-key.key
            {{- end -}}
```

Command ran to install the chart:
```
helm install --debug --name portworx \
--set etcdEndPoint=etcd:https://X.X.X.X:2379,clusterName=$(uuidgen) \
--set usedrivesAndPartitions=true \
--set drives=/dev/vda9 \
--set etcd.certPath=/etc/pwx/etcdcerts \
--set etcd.ca=/etc/pwx/etcdcerts/ca.pem \
--set etcd.cert=/etc/pwx/etcdcerts/client.pem \
--set etcd.key=/etc/pwx/etcdcerts/client-key.pem .
```

**Which issue(s) this PR fixes** (optional)
No one.

**Special notes for your reviewer**:

