### PR TITLE
fix helm rendering error

### DIFF
--- a/charts/portworx/templates/portworx-controller.yaml
+++ b/charts/portworx/templates/portworx-controller.yaml
@@ -91,7 +91,7 @@ spec:
       imagePullSecrets:
         - name: {{ required "A registry secret is required for openshift installation" .Values.registrySecret }}
      {{- else }}
-      {{- if not empty .Values.registrySecret }}
+      {{- if not (empty .Values.registrySecret) }}
       imagePullSecrets:
         - name: {{ .Values.registrySecret }}
       {{- end }}    


### PR DESCRIPTION
Signed-off-by: Sathya Balakrishnan <sathya@portworx.com>

<!--
  Make sure to have done the following:
  [x] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
This fixes a rendering issue with helm
```Error: render error in "portworx/templates/portworx-controller.yaml": template: portworx/templates/portworx-controller.yaml:94:13: executing "portworx/templates/portworx-controller.yaml" at <not>: wrong number of args for not: want 1 got 2```
![image](https://user-images.githubusercontent.com/42478164/59454676-7c019e80-8dc7-11e9-86a3-a669bd999bce.png)


**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

