### PR TITLE
honor px/enabled label for all portworx components (csi,stork,lh,pvc-…

### DIFF
--- a/charts/portworx/templates/portworx-controller.yaml
+++ b/charts/portworx/templates/portworx-controller.yaml
@@ -94,7 +94,7 @@ spec:
       {{- if not (empty .Values.registrySecret) }}
       imagePullSecrets:
         - name: {{ .Values.registrySecret }}
-      {{- end }}    
+      {{- end }}
      {{- end }}
       containers:
       - command:
@@ -120,6 +120,14 @@ spec:
             cpu: 200m
       hostNetwork: true
       affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: px/enabled
+                operator: NotIn
+                values:
+                - "false"
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:

--- a/charts/portworx/templates/portworx-csi.yaml
+++ b/charts/portworx/templates/portworx-csi.yaml
@@ -65,7 +65,7 @@ spec:
       containers:
         - name: csi-external-provisioner
           imagePullPolicy: Always
-          image: "{{ template "px.getcsiProvisioner" . }}/csi-provisioner:v0.2.0"
+          image: "{{ template "px.getcsiImages" . }}/csi-provisioner:v0.2.0"
           args:
             - "--v=5"
             - "--provisioner=com.openstorage.pxd"
@@ -93,4 +93,13 @@ spec:
           hostPath:
             path: /var/lib/kubelet/plugins/com.openstorage.pxd
             type: DirectoryOrCreate
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: px/enabled
+                operator: NotIn
+                values:
+                - "false"
 {{- end }}

--- a/charts/portworx/templates/portworx-lighthouse.yaml
+++ b/charts/portworx/templates/portworx-lighthouse.yaml
@@ -112,4 +112,13 @@ spec:
       volumes:
       - name: config
         emptyDir: {}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: px/enabled
+                operator: NotIn
+                values:
+                - "false"
 {{- end -}}

--- a/charts/portworx/templates/portworx-stork.yaml
+++ b/charts/portworx/templates/portworx-stork.yaml
@@ -180,6 +180,14 @@ spec:
         name: stork
       hostPID: false
       affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: px/enabled
+                operator: NotIn
+                values:
+                - "false"
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
@@ -309,6 +317,14 @@ spec:
           requests:
             cpu: '0.1'
       affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: px/enabled
+                operator: NotIn
+                values:
+                - "false"
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:


### PR DESCRIPTION
…controller)

Signed-off-by: Sathya Balakrishnan <sathya@portworx.com>

<!--
  Make sure to have done the following:
  [x] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
This change takes into account `px/enabled` labels for all portworx components (csi,stork,lh,pvc-controller,stork-scheduler)

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

