### PR TITLE
fix image URL construction in case of customRegistryURL

### DIFF
--- a/charts/portworx/templates/_helpers.tpl
+++ b/charts/portworx/templates/_helpers.tpl
@@ -67,7 +67,7 @@ release: {{ .Release.Name | quote }}
     {{- if (eq "/" (.Values.customRegistryURL | regexFind "/")) -}}
         {{ trim .Values.customRegistryURL }}
     {{- else -}}
-        {{cat (trim .Values.customRegistryURL) "/gcr.io/google_containers" | replace " " ""}}
+        {{cat (trim .Values.customRegistryURL) "/google_containers" | replace " " ""}}
     {{- end -}}
 {{- else -}}
         {{ "gcr.io/google_containers" }}
@@ -79,7 +79,7 @@ release: {{ .Release.Name | quote }}
     {{- if (eq "/" (.Values.customRegistryURL | regexFind "/")) -}}
         {{ trim .Values.customRegistryURL }}
     {{- else -}}
-        {{cat (trim .Values.customRegistryURL) "/quay.io/k8scsi" | replace " " ""}}
+        {{cat (trim .Values.customRegistryURL) "/k8scsi" | replace " " ""}}
     {{- end -}}
 {{- else -}}
         {{ "quay.io/k8scsi" }}

--- a/charts/portworx/templates/portworx-ds.yaml
+++ b/charts/portworx/templates/portworx-ds.yaml
@@ -49,7 +49,7 @@ spec:
         # {{- include "px.labels" . | indent 8 }}
     spec:
       tolerations:
-{{ toYaml .Values.tolerations | indent 8 }} 
+{{ toYaml .Values.tolerations | indent 8 }}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -293,7 +293,7 @@ spec:
           {{- if eq $customRegistryURL "none" }}
           image: "quay.io/k8scsi/driver-registrar:v0.2.0"
           {{- else }}
-          image: "{{ $customRegistryURL }}/quay.io/k8scsi/driver-registrar:v0.2.0"
+          image: "{{ $customRegistryURL }}/k8scsi/driver-registrar:v0.2.0"
           {{- end}}
           args:
             - "--v=5"


### PR DESCRIPTION
Signed-off-by: Sathya Balakrishnan <sathya@portworx.com>

<!--
  Make sure to have done the following:
  [x] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Fixes generating image URL when a custom registry is specified

Test:
```
helm install --debug --name my-release --set etcdEndPoint=etcd:http://192.168.70.90:2379,clusterName=$(uuidgen) . --dry-run | grep image
imageType: none
imageVersion: 2.0.3.6
        image: "lachlanevenson/k8s-kubectl:v1.13.5"
        imagePullPolicy: Always
        image: "portworx/px-etcd-preinstall-hook:v1.2"
        image: "lachlanevenson/k8s-kubectl:v1.13.5"
    portworx.com/helm-vars: chart="portworx-1.0.0",clusterName="41D8EF1F-F3D2-4D95-AA7B-F1020083A715",consul="map[token:none]",dataInterface="none",deploymentType="oci",drives="none",envVars="none",etcd="map[ca:none cert:none certPath:none credentials:none:none key:none]",etcdEndPoint="etcd:http://192.168.70.90:2379",imageType="none",imageVersion="2.0.3.6",lighthouse="true",lighthouseStorkConnectorVersion="0.2",lighthouseSyncVersion="0.4",lighthouseVersion="2.0.4",managementInterface="none",secretType="k8s",serviceAccount="map[hook:map[create:true name:<nil>]]",stork="true",storkVersion="2.1.1"
          image: portworx/oci-monitor:2.0.3.6
          imagePullPolicy: Always
            initialDelaySeconds: 840 # allow image pull in slow networks
        image: "portworx/lh-config-sync:0.4"
        imagePullPolicy: Always
        image: "portworx/px-lighthouse:2.0.4"
        imagePullPolicy: Always
        image: "portworx/lh-config-sync:0.4"
        imagePullPolicy: Always
        image: "portworx/lh-stork-connector:0.2"
        imagePullPolicy: Always
        image: "gcr.io/google_containers/kube-scheduler-amd64:v1.13.5"
        imagePullPolicy: Always
        image: openstorage/stork:2.1.1

  ~//helm/charts/portworx     customregistryurl-fix 
   helm install --debug --name my-release --set etcdEndPoint=etcd:http://192.168.70.90:2379,clusterName=$(uuidgen),customRegistryURL=myrep.com . --dry-run | grep image
imageType: none
imageVersion: 2.0.3.6
        image: "myrep.com/lachlanevenson/k8s-kubectl:v1.13.5"
        image: "myrep.com/lachlanevenson/k8s-kubectl:v1.13.5"
        imagePullPolicy: Always
        image: "myrep.com/portworx/px-etcd-preinstall-hook:v1.2"
    portworx.com/helm-vars: chart="portworx-1.0.0",clusterName="85254844-2690-4324-B2D1-F5AFF1C07711",consul="map[token:none]",customRegistryURL="myrep.com",dataInterface="none",deploymentType="oci",drives="none",envVars="none",etcd="map[ca:none cert:none certPath:none credentials:none:none key:none]",etcdEndPoint="etcd:http://192.168.70.90:2379",imageType="none",imageVersion="2.0.3.6",lighthouse="true",lighthouseStorkConnectorVersion="0.2",lighthouseSyncVersion="0.4",lighthouseVersion="2.0.4",managementInterface="none",secretType="k8s",serviceAccount="map[hook:map[create:true name:<nil>]]",stork="true",storkVersion="2.1.1"
          image: myrep.com/portworx/oci-monitor:2.0.3.6
          imagePullPolicy: Always
            initialDelaySeconds: 840 # allow image pull in slow networks
        image: "myrep.com/portworx/lh-config-sync:0.4"
        imagePullPolicy: Always
        image: "myrep.com/portworx/px-lighthouse:2.0.4"
        imagePullPolicy: Always
        image: "myrep.com/portworx/lh-config-sync:0.4"
        imagePullPolicy: Always
        image: "myrep.com/portworx/lh-stork-connector:0.2"
        imagePullPolicy: Always
        image: "myrep.com/google_containers/kube-scheduler-amd64:v1.13.5"
        imagePullPolicy: Always
        image: myrep.com/openstorage/stork:2.1.1
```

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

