### PR TITLE
[STORK] Affinity and Tolerations options on Deployments

### DIFF
--- a/charts/portworx/templates/portworx-lighthouse.yaml
+++ b/charts/portworx/templates/portworx-lighthouse.yaml
@@ -112,6 +112,8 @@ spec:
       volumes:
       - name: config
         emptyDir: {}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/charts/portworx/templates/portworx-stork.yaml
+++ b/charts/portworx/templates/portworx-stork.yaml
@@ -179,6 +179,8 @@ spec:
             cpu: '0.1'
         name: stork
       hostPID: false
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -308,6 +310,8 @@ spec:
         resources:
           requests:
             cpu: '0.1'
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/charts/portworx/templates/portworx-stork.yaml
+++ b/charts/portworx/templates/portworx-stork.yaml
@@ -180,14 +180,6 @@ spec:
         name: stork
       hostPID: false
       affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: px/enabled
-                operator: NotIn
-                values:
-                - "false"
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
@@ -317,14 +309,6 @@ spec:
           requests:
             cpu: '0.1'
       affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: px/enabled
-                operator: NotIn
-                values:
-                - "false"
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:


### PR DESCRIPTION
Remove the nodeAffinity rule from stork/stork-scheduler deployments, Stork can run on any node, it talks to PX over the service IP.

Also, add the possibility to add tolerations on stork/storck-scheduler deployments. We use the same tolerations than PX deployments.