### PR TITLE
PSG-98: Add azure env vars from secret for AKS installations

### DIFF
--- a/charts/portworx/README.md
+++ b/charts/portworx/README.md
@@ -35,10 +35,11 @@ The following tables lists the configurable parameters of the Portworx chart and
 |             Parameter       |            Description             |                    Default                |
 |-----------------------------|------------------------------------|-------------------------------------------|
 | `deploymentType`            | The deployment type. Can be either docker/oci   | `oci`                 |
-| `imageVersion`              | The image tag to pull              | `2.0.3.4`                                  |
+| `imageVersion`              | The image tag to pull              | `2.1.3`                                  |
 | `openshiftInstall`               | Installing on Openshift? | `false`                               |
 | `pksInstall`               | Installing on Pivotal Container service? | `false`                               |
-| `AKSorEKSInstall`               | Installing on AKS(Azure Kubernetes service) or EKS (Amazon Elastic Container service) | `false`                               |
+| `EKSInstall`               | Installing EKS (Amazon Elastic Container service) | `false`                               |
+| `AKSInstall`               | Installing on AKS (Azure Kubernetes service) | `false`                               |
 | `etcdEndPoint`          | (REQUIRED) ETCD endpoint for PX to function properly in the form "etcd:http://<your-etcd-endpoint>". Multiple Urls should be semi-colon seperated example: etcd:http://<your-etcd-endpoint1>;etcd:http://<your-etcd-endpoint2>  | `etcd:http://<your-etcd-endpoint>`                    |
 | `clusterName`           | Portworx Cluster Name  | `mycluster`                                     |
 | `usefileSystemDrive`      | Should Portworx use an unmounted drive even with a filesystem ? | `false`                |
@@ -65,6 +66,12 @@ The following tables lists the configurable parameters of the Portworx chart and
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+## Cloud installs
+
+#### Installing on AKS 
+
+Details are [here](https://docs.portworx.com/portworx-install-with-kubernetes/cloud/azure/aks/2-deploy-px/).
 
 > **Tip**: In this case the chart is located at `./helm/charts/portworx`, do change it as per your setup.
 ```

--- a/charts/portworx/templates/portworx-controller.yaml
+++ b/charts/portworx/templates/portworx-controller.yaml
@@ -1,4 +1,5 @@
-{{- if or ((.Values.openshiftInstall) and (eq .Values.openshiftInstall true)) ((.Values.AKSorEKSInstall) and (eq .Values.AKSorEKSInstall true)) ((.Capabilities.KubeVersion.GitVersion | regexMatch "gke")) }}
+{{- $AKSorEKSInstall := or .Values.AKSInstall  .Values.EKSInstall  }}
+{{- if or ((.Values.openshiftInstall) and (eq .Values.openshiftInstall true)) ($AKSorEKSInstall) ((.Capabilities.KubeVersion.GitVersion | regexMatch "gke")) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/portworx/templates/portworx-ds.yaml
+++ b/charts/portworx/templates/portworx-ds.yaml
@@ -49,7 +49,7 @@ spec:
         # {{- include "px.labels" . | indent 8 }}
     spec:
       tolerations:
-{{ toYaml .Values.tolerations | indent 8 }} 
+{{ toYaml .Values.tolerations | indent 8 }}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -82,18 +82,20 @@ spec:
           {{- with .Values }}
             [
               {{- if eq $drives "none" }}
-                {{- if eq $usedrivesAndPartitions true }}
-              "-A",
-                {{- else }}
-              "-a",
-                {{- end -}}
-                {{- if or $usefileSystemDrive $deployEnvironmentIKS }}
-              "-f",
-                {{- end }}
-              {{- else }}
+                  {{- if .AKSInstall -}}
+                   "-s", "type=Premium_LRS,size=150",
+                  {{- else if eq $usedrivesAndPartitions true }}
+                      "-A",
+                  {{- else }}
+                     "-a",
+                  {{- end -}}
+                 {{- if or $usefileSystemDrive $deployEnvironmentIKS }}
+                      "-f",
+                  {{- end }}
+              {{- else -}}
                 {{- $driveNames := $drives | split ";" }}
                 {{- range $index, $name := $driveNames }}
-              "-s", "{{ $name }}",
+                  "-s", "{{ $name }}",
                 {{- end -}}
               {{- end -}}
 
@@ -161,6 +163,23 @@ spec:
              ]
            {{- end }}
           env:
+          {{ if .Values.AKSInstall }}
+            - name: AZURE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: px-azure
+                  key: AZURE_CLIENT_SECRET
+            - name: AZURE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: px-azure
+                  key: AZURE_CLIENT_ID
+            - name: AZURE_TENANT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: px-azure
+                  key: AZURE_TENANT_ID
+          {{ end }}
             - name: "PX_TEMPLATE_VERSION"
               value: "v2"
               {{ if not (eq $envVars "none") }}

--- a/charts/portworx/values.yaml
+++ b/charts/portworx/values.yaml
@@ -2,25 +2,26 @@
 
 deploymentType: oci                     # accepts "oci" or "docker"
 imageType: none                         #
-imageVersion: 2.0.3.8                   # Version of the PX Image.
+imageVersion: 2.1.3                    # Version of the PX Image.
 
 openshiftInstall: false                 # Defaults to false for installing Portworx on Openshift .
 isTargetOSCoreOS: false                 # Is your target OS CoreOS? Defaults to false.
 pksInstall: false                       # installation on PKS (Pivotal Container Service)
-AKSorEKSInstall: false                  # installation on AKS or EKS.
+EKSInstall: false                     # installation on EKS.
+AKSInstall: false                      # installation on AKS
 etcdEndPoint:                         # The ETCD endpoint. Should be in the format etcd:http://<your-etcd-endpoint>:2379. If there are multiple etcd endpoints they need to be ";" seperated.
-                                        # the default value is empty since it requires to be explicity set using either the --set option of -f values.yaml.
+                                      # the default value is empty since it requires to be explicity set using either the --set option of -f values.yaml.
 clusterName: mycluster                # This is the default. please change it to your cluster name.
 usefileSystemDrive: false             # true/false Instructs PX to use an unmounted Drive even if it has a filesystem.
 usedrivesAndPartitions: false         # Defaults to false. Change to true and PX will use unmounted drives and partitions.
-secretType: k8s                      # Defaults to k8s, but can be kvdb/k8s/aws-kms/vault/ibm-kp. It is autopopulated to ibm-kp if the environment is IKS.
+secretType: k8s                       # Defaults to k8s, but can be kvdb/k8s/aws-kms/vault/ibm-kp. It is autopopulated to ibm-kp if the environment is IKS.
 drives: none                          # NOTE: This is a ";" seperated list of drives. For eg: "/dev/sda;/dev/sdb;/dev/sdc" Defaults to use -A switch.
 dataInterface: none                   # Name of the interface <ethX>
 managementInterface: none             # Name of the interface <ethX>
 envVars: none                         # NOTE: This is a ";" seperated list of environment variables. For eg: MYENV1=myvalue1;MYENV2=myvalue2
 
 stork: true                           # Use Stork https://docs.portworx.com/scheduler/kubernetes/stork.html for hyperconvergence.
-storkVersion: 2.1.2
+storkVersion: 2.2.4
 
 customRegistryURL:
 registrySecret:
@@ -45,9 +46,9 @@ etcd:
   cert: none                          # Location of certificate for ETCD authentication. Should be /path/to/server.crt
   key: none                           # Location of certificate key for ETCD authentication Should be /path/to/servery.key
 consul:
-  token: none                           # ACL token value used for Consul authentication. (example: 398073a8-5091-4d9c-871a-bbbeb030d1f6)
+  token: none                         # ACL token value used for Consul authentication. (example: 398073a8-5091-4d9c-871a-bbbeb030d1f6)
 
-tolerations:                           # Add tolerations
+tolerations:                          # Add tolerations
   #  - key: "key"
   #    operator: "Equal|Exists"
   #    value: "value"


### PR DESCRIPTION
Signed-off-by: trierra <oksana@portworx.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

To support AKS installations

**Which issue(s) this PR fixes** (optional)
Closes #PSG-98

**Special notes for your reviewer**:

updated oci-mon to v2.1.2 since 2.0.3.6 did not have azure support
