### PR TITLE
Bump lighthouse versions to 2.0.5

### DIFF
--- a/charts/portworx/values.yaml
+++ b/charts/portworx/values.yaml
@@ -27,9 +27,9 @@ customRegistryURL:
 registrySecret:
 
 lighthouse: true
-lighthouseVersion: 2.0.4
-lighthouseSyncVersion: 0.3
-lighthouseStorkConnectorVersion: 0.1
+lighthouseVersion: 2.0.5
+lighthouseSyncVersion: 2.0.5
+lighthouseStorkConnectorVersion: 2.0.5
 monitoring: false
 
 journalDevice:


### PR DESCRIPTION
Signed-off-by: Paul <paul@portworx.com>

**What this PR does / why we need it**:
Bump lighthouse version and dependend packages to 2.0.5

