### PR TITLE
PSG-134 Switch apiVersion to apps/v1 for DaemonSet and Deployment

### DIFF
--- a/charts/portworx/templates/portworx-controller.yaml
+++ b/charts/portworx/templates/portworx-controller.yaml
@@ -61,7 +61,7 @@ roleRef:
   name: portworx-pvc-controller-role
   apiGroup: rbac.authorization.k8s.io
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
@@ -71,6 +71,9 @@ metadata:
   name: portworx-pvc-controller
   namespace: kube-system
 spec:
+  selector:
+    matchLabels:
+      name: portworx-pvc-controller
   replicas: 3
   strategy:
     rollingUpdate:

--- a/charts/portworx/templates/portworx-csi.yaml
+++ b/charts/portworx/templates/portworx-csi.yaml
@@ -49,11 +49,14 @@ spec:
   clusterIP: None
 ---
 kind: StatefulSet
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 metadata:
   name: px-csi-ext
   namespace: kube-system
 spec:
+  selector:
+    matchLabels:
+      app: px-csi-driver
   serviceName: "px-csi-service"
   replicas: 1
   template:

--- a/charts/portworx/templates/portworx-ds.yaml
+++ b/charts/portworx/templates/portworx-ds.yaml
@@ -27,15 +27,20 @@
 {{- $etcdEndPoints := .Values.etcdEndPoint }}
 {{- $misc := .Values.misc | default "" | split " " }}
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: portworx
   namespace: kube-system
+  labels:
+    name: portworx
   annotations:
     portworx.com/install-source: helm/{{.Release.Service}}-r{{.Release.Revision}}
     portworx.com/helm-vars: chart="{{.Chart.Name}}-{{.Chart.Version}}"{{range $k, $v := .Values }}{{if $v}},{{ $k }}="{{ $v }}"{{end}}{{end}}
 spec:
+  selector:
+    matchLabels:
+      name: portworx
   minReadySeconds: 0
   updateStrategy:
     type: RollingUpdate

--- a/charts/portworx/templates/portworx-lighthouse.yaml
+++ b/charts/portworx/templates/portworx-lighthouse.yaml
@@ -74,7 +74,7 @@ spec:
   selector:
     tier: px-web-console
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: px-lighthouse
@@ -82,14 +82,14 @@ metadata:
   labels:
     tier: px-web-console
 spec:
+  selector:
+    matchLabels:
+      tier: px-web-console
   strategy:
     rollingUpdate:
       maxSurge: 1
       maxUnavailable: 1
     type: RollingUpdate
-  selector:
-    matchLabels:
-      tier: px-web-console
   replicas: 1
   template:
     metadata:

--- a/charts/portworx/templates/portworx-monitor.yaml
+++ b/charts/portworx/templates/portworx-monitor.yaml
@@ -72,7 +72,7 @@ metadata:
   name: prometheus-operator
   namespace: kube-system
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -80,6 +80,9 @@ metadata:
   name: prometheus-operator
   namespace: kube-system
 spec:
+  selector:
+    matchLabels:
+      k8s-app: prometheus-operator
   replicas: 1
   template:
     metadata:
@@ -455,7 +458,7 @@ spec:
   selector:
     app: grafana
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: grafana
@@ -463,6 +466,9 @@ metadata:
   labels:
     app: grafana
 spec:
+  selector:
+    matchLabels:
+      app: grafana
   replicas: 1
   template:
     metadata:

--- a/charts/portworx/templates/portworx-storageclasses.yaml
+++ b/charts/portworx/templates/portworx-storageclasses.yaml
@@ -1,5 +1,5 @@
 kind: StorageClass
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 metadata:
   name: portworx-db-sc
 provisioner: kubernetes.io/portworx-volume
@@ -8,7 +8,7 @@ parameters:
   io_profile: "db"
 ---
 kind: StorageClass
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 metadata:
   name: portworx-db2-sc
 provisioner: kubernetes.io/portworx-volume
@@ -18,7 +18,7 @@ parameters:
    io_profile: "db"
 ---
 kind: StorageClass
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 metadata:
   name: portworx-shared-sc
 provisioner: kubernetes.io/portworx-volume
@@ -33,7 +33,7 @@ parameters:
 # Please refer to : https://docs.portworx.com/scheduler/kubernetes/dynamic-provisioning.html
 #
 kind: StorageClass
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 metadata:
   name: portworx-null-sc
   annotations:

--- a/charts/portworx/templates/portworx-stork.yaml
+++ b/charts/portworx/templates/portworx-stork.yaml
@@ -93,7 +93,7 @@ spec:
       port: 8099
       targetPort: 8099
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
@@ -103,6 +103,9 @@ metadata:
   name: stork
   namespace: kube-system
 spec:
+  selector:
+    matchLabels:
+      name: stork
   strategy:
     rollingUpdate:
       maxSurge: 1
@@ -228,21 +231,26 @@ roleRef:
   name: stork-scheduler-role
   apiGroup: rbac.authorization.k8s.io
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
     component: scheduler
     tier: control-plane
+    name: stork-scheduler
   name: stork-scheduler
   namespace: kube-system
 spec:
+  selector:
+    matchLabels:
+      name: stork-scheduler
   replicas: 3
   template:
     metadata:
       labels:
         component: scheduler
         tier: control-plane
+        name: stork-scheduler
       name: stork-scheduler
     spec:
       containers:


### PR DESCRIPTION
**What this PR does / why we need it**:

This is needed to have helm install work on Kubernetes 1.16

**Which issue(s) this PR fixes** (optional)

PSG-134
