### PR TITLE
Remove full FQDN to avoid custom cluster name

### DIFF
--- a/charts/portworx/templates/portworx-stork.yaml
+++ b/charts/portworx/templates/portworx-stork.yaml
@@ -41,7 +41,7 @@ data:
 {{- end}}
       "extenders": [
         {
-          "urlPrefix": "http://stork-service.kube-system.svc.cluster.local:8099",
+          "urlPrefix": "http://stork-service.kube-system:8099",
           "apiVersion": "v1beta1",
           "filterVerb": "filter",
           "prioritizeVerb": "prioritize",


### PR DESCRIPTION
  Warning  FailedScheduling  119s (x29 over 12m)  stork  Post http://stork-service.kube-system.svc.cluster.local:8099/filter: dial tcp: lookup stork-service.kube-system.svc.cluster.local on 10.0.220.2:53: no such host