### PR TITLE
Added option to require px/enabled label on hosts.

### DIFF
--- a/charts/portworx/templates/_helpers.tpl
+++ b/charts/portworx/templates/_helpers.tpl
@@ -188,3 +188,21 @@ Generate a random token for storage provisioning
 {{- define "portworx-cluster-key" -}}
 {{- randAlphaNum 16 | nospace | b64enc -}}
 {{- end -}}
+
+
+{{- define "px.affinityPxEnabledOperator" -}}
+{{- if .Values.requirePxEnabledTag -}}
+    {{- "In" }}
+{{- else -}}
+    {{ "NotIn" }}
+{{- end -}}
+{{- end -}}
+
+
+{{- define "px.affinityPxEnabledValue" -}}
+{{- if .Values.requirePxEnabledTag -}}
+    {{- "true"  | quote }}
+{{- else -}}
+    {{ "false" | quote }}
+{{- end -}}
+{{- end -}}

--- a/charts/portworx/templates/portworx-controller.yaml
+++ b/charts/portworx/templates/portworx-controller.yaml
@@ -133,9 +133,9 @@ spec:
             nodeSelectorTerms:
             - matchExpressions:
               - key: px/enabled
-                operator: NotIn
+                operator: {{ template "px.affinityPxEnabledOperator" . }}
                 values:
-                - "false"
+                - {{ template "px.affinityPxEnabledValue" . }}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:

--- a/charts/portworx/templates/portworx-csi.yaml
+++ b/charts/portworx/templates/portworx-csi.yaml
@@ -106,7 +106,7 @@ spec:
             nodeSelectorTerms:
             - matchExpressions:
               - key: px/enabled
-                operator: NotIn
+                operator: {{ template "px.affinityPxEnabledOperator" . }}
                 values:
-                - "false"
+                - {{ template "px.affinityPxEnabledValue" . }}
 {{- end }}

--- a/charts/portworx/templates/portworx-ds.yaml
+++ b/charts/portworx/templates/portworx-ds.yaml
@@ -63,9 +63,9 @@ spec:
             nodeSelectorTerms:
             - matchExpressions:
               - key: px/enabled
-                operator: NotIn
+                operator:  {{ template "px.affinityPxEnabledOperator" . }}
                 values:
-                - "false"
+                - {{ template "px.affinityPxEnabledValue" . }}
               {{- if (.Values.openshiftInstall) and (eq .Values.openshiftInstall true)}}
               - key: openshift-infra
                 operator: DoesNotExist
@@ -455,9 +455,9 @@ spec:
             nodeSelectorTerms:
               - matchExpressions:
                   - key: px/enabled
-                    operator: NotIn
+                    operator: {{ template "px.affinityPxEnabledOperator" . }}
                     values:
-                      - "false"
+                      -  {{ template "px.affinityPxEnabledValue" . }}
                   - key: node-role.kubernetes.io/master
                     operator: DoesNotExist
       hostNetwork: true

--- a/charts/portworx/templates/portworx-lighthouse.yaml
+++ b/charts/portworx/templates/portworx-lighthouse.yaml
@@ -141,7 +141,7 @@ spec:
             nodeSelectorTerms:
             - matchExpressions:
               - key: px/enabled
-                operator: NotIn
+                operator: {{ template "px.affinityPxEnabledOperator" . }}
                 values:
-                - "false"
+                - {{ template "px.affinityPxEnabledValue" . }}
 {{- end -}}

--- a/charts/portworx/templates/portworx-stork.yaml
+++ b/charts/portworx/templates/portworx-stork.yaml
@@ -147,9 +147,9 @@ spec:
             nodeSelectorTerms:
             - matchExpressions:
               - key: px/enabled
-                operator: NotIn
+                operator: {{ template "px.affinityPxEnabledOperator" . }}
                 values:
-                - "false"
+                - {{ template "px.affinityPxEnabledValue" . }}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
@@ -304,9 +304,9 @@ spec:
             nodeSelectorTerms:
             - matchExpressions:
               - key: px/enabled
-                operator: NotIn
+                operator: {{ template "px.affinityPxEnabledOperator" . }}
                 values:
-                - "false"
+                - {{ template "px.affinityPxEnabledValue" . }}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:

--- a/charts/portworx/values.yaml
+++ b/charts/portworx/values.yaml
@@ -66,3 +66,5 @@ clusterToken:
 
 replicas: 3                         # Replica count for pvc-controller, stork, stork-scheduler.
 
+#requirePxEnabledTag: true               # if set to true, portworx will only install on nodes with px/enabled: true label. Not required in most scenarios.
+


### PR DESCRIPTION
Introduced a new value requirePxEnabledTag. 

When set to true, portworx workloads will only install across nodes when px/enabled: true label is set on node. 

This feature is useful in eks/autoscaling environments where you want to stop portworx from automatically rolling out to newly provisioned nodes (where the node count is higher than 3). Without this behaviour, portworx DS will always try and install across all available nodes even though the  cluster limit is dependant on license restrictions. 

