### PR TITLE
Updating monitoring templates and fixes for helm 3 (infix

### DIFF
--- a/charts/portworx/files/portworx-cluster-dashboard.json
+++ b/charts/portworx/files/portworx-cluster-dashboard.json
@@ -1,975 +1,975 @@
-	{
-		"__inputs": [
-			{
-				"description": "",
-				"label": "prometheus",
-				"name": "DS_PROMETHEUS",
-				"pluginId": "prometheus",
-				"pluginName": "Prometheus",
-				"type": "datasource"
-			}
-		],
-		"__requires": [
-			{
-				"id": "grafana",
-				"name": "Grafana",
-				"type": "grafana",
-				"version": "5.0.0-beta1"
-			},
-			{
-				"id": "heatmap",
-				"name": "Heatmap",
-				"type": "panel",
-				"version": ""
-			},
-			{
-				"id": "prometheus",
-				"name": "Prometheus",
-				"type": "datasource",
-				"version": "1.0.0"
-			},
-			{
-				"id": "singlestat",
-				"name": "Singlestat",
-				"type": "panel",
-				"version": ""
-			}
-		],
-		"annotations": {
-			"list": [
-				{
-					"builtIn": 1,
-					"datasource": "-- Grafana --",
-					"enable": true,
-					"hide": true,
-					"iconColor": "rgba(0, 211, 255, 1)",
-					"name": "Annotations & Alerts",
-					"type": "dashboard"
-				}
-			]
-		},
-		"editable": true,
-		"gnetId": null,
-		"graphTooltip": 0,
-		"id": null,
-		"iteration": 1541099197839,
-		"links": [],
-		"panels": [
-			{
-				"collapsed": false,
-				"gridPos": {
-					"h": 1,
-					"w": 24,
-					"x": 0,
-					"y": 0
-				},
-				"id": 54,
-				"panels": [],
-				"repeat": null,
-				"title": "Portworx Cluster \"[[Cluster]]\"",
-				"type": "row"
-			},
-			{
-				"cacheTimeout": null,
-				"colorBackground": false,
-				"colorValue": true,
-				"colors": [
-					"#fce2de",
-					"#eab839",
-					"#bf1b00"
-				],
-				"datasource": "prometheus",
-				"format": "percent",
-				"gauge": {
-					"maxValue": 100,
-					"minValue": 0,
-					"show": true,
-					"thresholdLabels": false,
-					"thresholdMarkers": true
-				},
-				"gridPos": {
-					"h": 4,
-					"w": 4,
-					"x": 0,
-					"y": 1
-				},
-				"id": 56,
-				"interval": null,
-				"links": [],
-				"mappingType": 1,
-				"mappingTypes": [
-					{
-						"name": "value to text",
-						"value": 1
-					},
-					{
-						"name": "range to text",
-						"value": 2
-					}
-				],
-				"maxDataPoints": 100,
-				"nullPointMode": "connected",
-				"nullText": null,
-				"postfix": "",
-				"postfixFontSize": "50%",
-				"prefix": "",
-				"prefixFontSize": "50%",
-				"rangeMaps": [
-					{
-						"from": "null",
-						"text": "N/A",
-						"to": "null"
-					}
-				],
-				"sparkline": {
-					"fillColor": "rgba(31, 118, 189, 0.18)",
-					"full": true,
-					"lineColor": "rgb(31, 120, 193)",
-					"show": false
-				},
-				"tableColumn": "",
-				"targets": [
-					{
-						"expr": "sum(px_cluster_disk_utilized_bytes{cluster=~\"[[Cluster]]\"})/sum(px_cluster_disk_total_bytes{cluster=~\"[[Cluster]]\"})",
-						"format": "time_series",
-						"intervalFactor": 1,
-						"legendFormat": "",
-						"refId": "A"
-					}
-				],
-				"thresholds": "80,90",
-				"title": "Usage Meter",
-				"type": "singlestat",
-				"valueFontSize": "80%",
-				"valueMaps": [
-					{
-						"op": "=",
-						"text": "N/A",
-						"value": "null"
-					}
-				],
-				"valueName": "total"
-			},
-			{
-				"cacheTimeout": null,
-				"colorBackground": false,
-				"colorValue": false,
-				"colors": [
-					"#299c46",
-					"rgba(237, 129, 40, 0.89)",
-					"#d44a3a"
-				],
-				"datasource": "prometheus",
-				"format": "bytes",
-				"gauge": {
-					"maxValue": 100,
-					"minValue": 0,
-					"show": false,
-					"thresholdLabels": false,
-					"thresholdMarkers": true
-				},
-				"gridPos": {
-					"h": 4,
-					"w": 4,
-					"x": 4,
-					"y": 1
-				},
-				"id": 63,
-				"interval": null,
-				"links": [
-					{
-						"dashUri": "db/portworx-volume-dashboard",
-						"dashboard": "Portworx Volume Dashboard",
-						"includeVars": true,
-						"keepTime": true,
-						"targetBlank": true,
-						"title": "Portworx Volume Dashboard",
-						"type": "dashboard"
-					}
-				],
-				"mappingType": 1,
-				"mappingTypes": [
-					{
-						"name": "value to text",
-						"value": 1
-					},
-					{
-						"name": "range to text",
-						"value": 2
-					}
-				],
-				"maxDataPoints": 100,
-				"nullPointMode": "connected",
-				"nullText": null,
-				"postfix": "",
-				"postfixFontSize": "50%",
-				"prefix": "",
-				"prefixFontSize": "50%",
-				"rangeMaps": [
-					{
-						"from": "null",
-						"text": "N/A",
-						"to": "null"
-					}
-				],
-				"sparkline": {
-					"fillColor": "rgba(31, 118, 189, 0.18)",
-					"full": true,
-					"lineColor": "rgb(31, 120, 193)",
-					"show": true
-				},
-				"tableColumn": "",
-				"targets": [
-					{
-						"expr": "sum(px_cluster_disk_utilized_bytes{cluster=~\"[[Cluster]]\"})",
-						"format": "time_series",
-						"intervalFactor": 1,
-						"legendFormat": "",
-						"refId": "A"
-					}
-				],
-				"thresholds": "",
-				"title": "Capacity Used",
-				"transparent": false,
-				"type": "singlestat",
-				"valueFontSize": "80%",
-				"valueMaps": [
-					{
-						"op": "=",
-						"text": "N/A",
-						"value": "null"
-					}
-				],
-				"valueName": "current"
-			},
-			{
-				"cacheTimeout": null,
-				"colorBackground": false,
-				"colorValue": false,
-				"colors": [
-					"#299c46",
-					"rgba(237, 129, 40, 0.89)",
-					"#d44a3a"
-				],
-				"datasource": "prometheus",
-				"format": "percent",
-				"gauge": {
-					"maxValue": 100,
-					"minValue": 0,
-					"show": false,
-					"thresholdLabels": false,
-					"thresholdMarkers": true
-				},
-				"gridPos": {
-					"h": 4,
-					"w": 4,
-					"x": 8,
-					"y": 1
-				},
-				"id": 61,
-				"interval": null,
-				"links": [],
-				"mappingType": 1,
-				"mappingTypes": [
-					{
-						"name": "value to text",
-						"value": 1
-					},
-					{
-						"name": "range to text",
-						"value": 2
-					}
-				],
-				"maxDataPoints": 100,
-				"nullPointMode": "connected",
-				"nullText": null,
-				"postfix": "",
-				"postfixFontSize": "50%",
-				"prefix": "",
-				"prefixFontSize": "50%",
-				"rangeMaps": [
-					{
-						"from": "null",
-						"text": "N/A",
-						"to": "null"
-					}
-				],
-				"sparkline": {
-					"fillColor": "rgba(31, 118, 189, 0.18)",
-					"full": true,
-					"lineColor": "rgb(31, 120, 193)",
-					"show": true
-				},
-				"tableColumn": "",
-				"targets": [
-					{
-						"expr": "avg(px_cluster_cpu_percent{cluster=~\"[[Cluster]]\"})",
-						"format": "time_series",
-						"intervalFactor": 1,
-						"legendFormat": "",
-						"refId": "A"
-					}
-				],
-				"thresholds": "",
-				"title": "Avg. Cluster CPU",
-				"type": "singlestat",
-				"valueFontSize": "80%",
-				"valueMaps": [
-					{
-						"op": "=",
-						"text": "N/A",
-						"value": "null"
-					}
-				],
-				"valueName": "current"
-			},
-			{
-				"cacheTimeout": null,
-				"colorBackground": false,
-				"colorValue": false,
-				"colors": [
-					"#299c46",
-					"rgba(237, 129, 40, 0.89)",
-					"#d44a3a"
-				],
-				"datasource": "prometheus",
-				"format": "none",
-				"gauge": {
-					"maxValue": 100,
-					"minValue": 0,
-					"show": false,
-					"thresholdLabels": false,
-					"thresholdMarkers": true
-				},
-				"gridPos": {
-					"h": 2,
-					"w": 4,
-					"x": 12,
-					"y": 1
-				},
-				"id": 62,
-				"interval": null,
-				"links": [
-					{
-						"dashUri": "db/portworx-node-dashboard",
-						"dashboard": "Portworx Node Dashboard",
-						"includeVars": true,
-						"keepTime": true,
-						"targetBlank": true,
-						"title": "Portworx Node Dashboard",
-						"type": "dashboard"
-					}
-				],
-				"mappingType": 1,
-				"mappingTypes": [
-					{
-						"name": "value to text",
-						"value": 1
-					},
-					{
-						"name": "range to text",
-						"value": 2
-					}
-				],
-				"maxDataPoints": 100,
-				"nullPointMode": "connected",
-				"nullText": null,
-				"postfix": "",
-				"postfixFontSize": "50%",
-				"prefix": "",
-				"prefixFontSize": "50%",
-				"rangeMaps": [
-					{
-						"from": "null",
-						"text": "N/A",
-						"to": "null"
-					}
-				],
-				"sparkline": {
-					"fillColor": "rgba(31, 118, 189, 0.18)",
-					"full": true,
-					"lineColor": "rgb(31, 120, 193)",
-					"show": true
-				},
-				"tableColumn": "",
-				"targets": [
-					{
-						"expr": "min(px_cluster_status_cluster_size{cluster=~\"[[Cluster]]\"}) ",
-						"format": "time_series",
-						"intervalFactor": 1,
-						"legendFormat": "",
-						"refId": "A"
-					}
-				],
-				"thresholds": "",
-				"title": "# Nodes (total)",
-				"transparent": false,
-				"type": "singlestat",
-				"valueFontSize": "80%",
-				"valueMaps": [],
-				"valueName": "current"
-			},
-			{
-				"cacheTimeout": null,
-				"colorBackground": true,
-				"colorValue": false,
-				"colors": [
-					"#299c46",
-					"#629e51",
-					"#d44a3a"
-				],
-				"datasource": "prometheus",
-				"format": "short",
-				"gauge": {
-					"maxValue": 100,
-					"minValue": 0,
-					"show": false,
-					"thresholdLabels": false,
-					"thresholdMarkers": true
-				},
-				"gridPos": {
-					"h": 4,
-					"w": 4,
-					"x": 16,
-					"y": 1
-				},
-				"hideTimeOverride": true,
-				"id": 81,
-				"interval": "15s",
-				"links": [],
-				"mappingType": 2,
-				"mappingTypes": [
-					{
-						"name": "value to text",
-						"value": 1
-					},
-					{
-						"name": "range to text",
-						"value": 2
-					}
-				],
-				"maxDataPoints": 100,
-				"nullPointMode": "connected",
-				"nullText": null,
-				"postfix": "",
-				"postfixFontSize": "50%",
-				"prefix": "",
-				"prefixFontSize": "50%",
-				"rangeMaps": [
-					{
-						"from": "2",
-						"text": "Quorum Unhealthy",
-						"to": "1000"
-					},
-					{
-						"from": "0",
-						"text": "Quorum Healthy",
-						"to": "1.99"
-					}
-				],
-				"sparkline": {
-					"fillColor": "rgba(31, 118, 189, 0.18)",
-					"full": false,
-					"lineColor": "rgb(31, 120, 193)",
-					"show": false
-				},
-				"tableColumn": "",
-				"targets": [
-					{
-						"expr": "min(px_cluster_status_cluster_size{cluster=~\"[[Cluster]]\"})/sum(px_cluster_status_cluster_quorum{cluster=~\"[[Cluster]]\"})",
-						"format": "time_series",
-						"interval": "",
-						"intervalFactor": 2,
-						"legendFormat": "",
-						"refId": "A"
-					}
-				],
-				"thresholds": "1.1,1.9",
-				"timeFrom": "1m",
-				"title": "Quorum",
-				"type": "singlestat",
-				"valueFontSize": "80%",
-				"valueMaps": [
-					{
-						"op": "=",
-						"text": "N/A",
-						"value": "2"
-					}
-				],
-				"valueName": "current"
-			},
-			{
-				"cacheTimeout": null,
-				"colorBackground": false,
-				"colorValue": false,
-				"colors": [
-					"#299c46",
-					"rgba(237, 129, 40, 0.89)",
-					"#d44a3a"
-				],
-				"datasource": "prometheus",
-				"format": "none",
-				"gauge": {
-					"maxValue": 100,
-					"minValue": 0,
-					"show": false,
-					"thresholdLabels": false,
-					"thresholdMarkers": true
-				},
-				"gridPos": {
-					"h": 2,
-					"w": 4,
-					"x": 20,
-					"y": 1
-				},
-				"id": 85,
-				"interval": null,
-				"links": [
-					{
-						"dashUri": "db/portworx-node-dashboard",
-						"dashboard": "Portworx Node Dashboard",
-						"includeVars": true,
-						"keepTime": true,
-						"targetBlank": true,
-						"title": "Portworx Node Dashboard",
-						"type": "dashboard"
-					}
-				],
-				"mappingType": 1,
-				"mappingTypes": [
-					{
-						"name": "value to text",
-						"value": 1
-					},
-					{
-						"name": "range to text",
-						"value": 2
-					}
-				],
-				"maxDataPoints": 100,
-				"nullPointMode": "connected",
-				"nullText": null,
-				"postfix": "",
-				"postfixFontSize": "50%",
-				"prefix": "",
-				"prefixFontSize": "50%",
-				"rangeMaps": [
-					{
-						"from": "null",
-						"text": "N/A",
-						"to": "null"
-					}
-				],
-				"sparkline": {
-					"fillColor": "rgba(31, 118, 189, 0.18)",
-					"full": true,
-					"lineColor": "rgb(31, 120, 193)",
-					"show": true
-				},
-				"tableColumn": "",
-				"targets": [
-					{
-						"expr": "min(px_cluster_status_nodes_online{cluster=~\"[[Cluster]]\"}) ",
-						"format": "time_series",
-						"intervalFactor": 1,
-						"legendFormat": "",
-						"refId": "A"
-					}
-				],
-				"thresholds": "",
-				"title": "# Nodes online",
-				"transparent": false,
-				"type": "singlestat",
-				"valueFontSize": "80%",
-				"valueMaps": [
-					{
-						"op": "=",
-						"text": "N/A",
-						"value": "null"
-					}
-				],
-				"valueName": "current"
-			},
-			{
-				"cacheTimeout": null,
-				"colorBackground": false,
-				"colorValue": false,
-				"colors": [
-					"#299c46",
-					"rgba(237, 129, 40, 0.89)",
-					"#d44a3a"
-				],
-				"datasource": "prometheus",
-				"format": "none",
-				"gauge": {
-					"maxValue": 100,
-					"minValue": 0,
-					"show": false,
-					"thresholdLabels": false,
-					"thresholdMarkers": true
-				},
-				"gridPos": {
-					"h": 2,
-					"w": 4,
-					"x": 12,
-					"y": 3
-				},
-				"id": 83,
-				"interval": null,
-				"links": [],
-				"mappingType": 1,
-				"mappingTypes": [
-					{
-						"name": "value to text",
-						"value": 1
-					},
-					{
-						"name": "range to text",
-						"value": 2
-					}
-				],
-				"maxDataPoints": 100,
-				"nullPointMode": "connected",
-				"nullText": null,
-				"postfix": "",
-				"postfixFontSize": "50%",
-				"prefix": "",
-				"prefixFontSize": "50%",
-				"rangeMaps": [
-					{
-						"from": "null",
-						"text": "N/A",
-						"to": "null"
-					}
-				],
-				"sparkline": {
-					"fillColor": "rgba(31, 118, 189, 0.18)",
-					"full": false,
-					"lineColor": "rgb(31, 120, 193)",
-					"show": false
-				},
-				"tableColumn": "",
-				"targets": [
-					{
-						"expr": "min(px_cluster_status_storage_nodes_online{cluster=~\"[[Cluster]]\"})",
-						"format": "time_series",
-						"intervalFactor": 1,
-						"refId": "A"
-					}
-				],
-				"thresholds": "",
-				"title": "Storage Providers",
-				"type": "singlestat",
-				"valueFontSize": "80%",
-				"valueMaps": [
-					{
-						"op": "=",
-						"text": "N/A",
-						"value": "null"
-					}
-				],
-				"valueName": "current"
-			},
-			{
-				"cacheTimeout": null,
-				"colorBackground": true,
-				"colorValue": false,
-				"colors": [
-					"#299c46",
-					"rgba(237, 129, 40, 0.89)",
-					"#d44a3a"
-				],
-				"datasource": "prometheus",
-				"format": "short",
-				"gauge": {
-					"maxValue": 100,
-					"minValue": 0,
-					"show": false,
-					"thresholdLabels": false,
-					"thresholdMarkers": true
-				},
-				"gridPos": {
-					"h": 2,
-					"w": 4,
-					"x": 20,
-					"y": 3
-				},
-				"id": 84,
-				"interval": null,
-				"links": [],
-				"mappingType": 2,
-				"mappingTypes": [
-					{
-						"name": "value to text",
-						"value": 1
-					},
-					{
-						"name": "range to text",
-						"value": 2
-					}
-				],
-				"maxDataPoints": 100,
-				"nullPointMode": "connected",
-				"nullText": null,
-				"postfix": "",
-				"postfixFontSize": "50%",
-				"prefix": "",
-				"prefixFontSize": "50%",
-				"rangeMaps": [
-					{
-						"from": "0",
-						"text": "All members online",
-						"to": "0"
-					},
-					{
-						"from": "1",
-						"text": "Members offline",
-						"to": "1"
-					},
-					{
-						"from": "2",
-						"text": "Members offline",
-						"to": "1000"
-					}
-				],
-				"sparkline": {
-					"fillColor": "rgba(31, 118, 189, 0.18)",
-					"full": true,
-					"lineColor": "rgb(31, 120, 193)",
-					"show": false
-				},
-				"tableColumn": "",
-				"targets": [
-					{
-						"expr": "min(px_cluster_status_cluster_size{cluster=\"[[Cluster]]\"})-min(px_cluster_status_storage_nodes_online{cluster=\"[[Cluster]]\"})",
-						"format": "time_series",
-						"instant": false,
-						"intervalFactor": 1,
-						"legendFormat": "",
-						"refId": "A"
-					}
-				],
-				"thresholds": "0.5,1",
-				"title": "",
-				"type": "singlestat",
-				"valueFontSize": "50%",
-				"valueMaps": [
-					{
-						"op": "=",
-						"text": "",
-						"value": "0"
-					},
-					{
-						"op": "=",
-						"text": "",
-						"value": ""
-					}
-				],
-				"valueName": "current"
-			},
-			{
-				"cards": {
-					"cardPadding": null,
-					"cardRound": null
-				},
-				"color": {
-					"cardColor": "#b4ff00",
-					"colorScale": "sqrt",
-					"colorScheme": "interpolateOranges",
-					"exponent": 0.5,
-					"mode": "spectrum"
-				},
-				"dataFormat": "timeseries",
-				"datasource": "prometheus",
-				"gridPos": {
-					"h": 8,
-					"w": 12,
-					"x": 0,
-					"y": 5
-				},
-				"heatmap": {},
-				"highlightCards": true,
-				"id": 78,
-				"legend": {
-					"show": true
-				},
-				"links": [
-					{
-						"dashUri": "db/portworx-node-dashboard",
-						"dashboard": "Portworx Node Dashboard",
-						"includeVars": true,
-						"keepTime": true,
-						"targetBlank": true,
-						"title": "Portworx Node Dashboard",
-						"type": "dashboard"
-					}
-				],
-				"targets": [
-					{
-						"expr": "px_cluster_cpu_percent{cluster =~ \"[[Cluster]]\"}",
-						"format": "time_series",
-						"interval": "5m",
-						"intervalFactor": 1,
-						"legendFormat": "",
-						"refId": "A"
-					}
-				],
-				"title": "CPU utilization heat map",
-				"tooltip": {
-					"show": true,
-					"showHistogram": true
-				},
-				"transparent": false,
-				"type": "heatmap",
-				"xAxis": {
-					"show": true
-				},
-				"xBucketNumber": null,
-				"xBucketSize": null,
-				"yAxis": {
-					"decimals": null,
-					"format": "percent",
-					"logBase": 1,
-					"max": null,
-					"min": null,
-					"show": true,
-					"splitFactor": null
-				},
-				"yBucketNumber": null,
-				"yBucketSize": null
-			},
-			{
-				"cards": {
-					"cardPadding": null,
-					"cardRound": null
-				},
-				"color": {
-					"cardColor": "#b4ff00",
-					"colorScale": "sqrt",
-					"colorScheme": "interpolateOranges",
-					"exponent": 0.5,
-					"mode": "spectrum"
-				},
-				"dataFormat": "timeseries",
-				"datasource": "prometheus",
-				"gridPos": {
-					"h": 8,
-					"w": 12,
-					"x": 12,
-					"y": 5
-				},
-				"heatmap": {},
-				"highlightCards": true,
-				"id": 79,
-				"legend": {
-					"show": true
-				},
-				"links": [
-					{
-						"dashUri": "db/portworx-node-dashboard",
-						"dashboard": "Portworx Node Dashboard",
-						"includeVars": true,
-						"keepTime": true,
-						"targetBlank": true,
-						"title": "Node Drilldown",
-						"type": "dashboard"
-					}
-				],
-				"repeat": null,
-				"repeatDirection": "h",
-				"targets": [
-					{
-						"expr": "px_cluster_memory_utilized_percent{cluster =~ \"[[Cluster]]\"}",
-						"format": "time_series",
-						"interval": "5m",
-						"intervalFactor": 1,
-						"legendFormat": "{{cluster}}",
-						"refId": "A"
-					}
-				],
-				"title": "Memory utilization heat map",
-				"tooltip": {
-					"show": true,
-					"showHistogram": true
-				},
-				"type": "heatmap",
-				"xAxis": {
-					"show": true
-				},
-				"xBucketNumber": null,
-				"xBucketSize": null,
-				"yAxis": {
-					"decimals": null,
-					"format": "percent",
-					"logBase": 1,
-					"max": null,
-					"min": null,
-					"show": true,
-					"splitFactor": null
-				},
-				"yBucketNumber": null,
-				"yBucketSize": null
-			}
-		],
-		"refresh": "30s",
-		"schemaVersion": 16,
-		"style": "dark",
-		"tags": [],
-		"templating": {
-			"list": [
-				{
-					"allValue": null,
-					"current": {},
-					"datasource": "prometheus",
-					"hide": 1,
-					"includeAll": false,
-					"label": "",
-					"multi": false,
-					"name": "Cluster",
-					"options": [],
-					"query": "px_cluster_cpu_percent",
-					"refresh": 1,
-					"regex": "/.*cluster=\"([^\"]*).*/",
-					"sort": 0,
-					"tagValuesQuery": "",
-					"tags": [],
-					"tagsQuery": "",
-					"type": "query",
-					"useTags": false
-				}
-			]
-		},
-		"time": {
-			"from": "now-3h",
-			"to": "now"
-		},
-		"timepicker": {
-			"refresh_intervals": [
-				"5s",
-				"10s",
-				"30s",
-				"1m",
-				"5m",
-				"15m",
-				"30m",
-				"1h",
-				"2h",
-				"1d"
-			],
-			"time_options": [
-				"5m",
-				"15m",
-				"1h",
-				"6h",
-				"12h",
-				"24h",
-				"2d",
-				"7d",
-				"30d"
-			]
-		},
-		"timezone": "",
-		"title": "Portworx Cluster Dashboard",
-		"uid": "xLgt8oTik",
-		"version": 6
-	}
+    {
+      "__inputs": [
+        {
+          "name": "DS_PROMETHEUS",
+          "label": "prometheus",
+          "description": "",
+          "type": "datasource",
+          "pluginId": "prometheus",
+          "pluginName": "Prometheus"
+        }
+      ],
+      "__requires": [
+        {
+          "type": "grafana",
+          "id": "grafana",
+          "name": "Grafana",
+          "version": "5.0.0-beta1"
+        },
+        {
+          "type": "panel",
+          "id": "heatmap",
+          "name": "Heatmap",
+          "version": ""
+        },
+        {
+          "type": "datasource",
+          "id": "prometheus",
+          "name": "Prometheus",
+          "version": "1.0.0"
+        },
+        {
+          "type": "panel",
+          "id": "singlestat",
+          "name": "Singlestat",
+          "version": ""
+        }
+      ],
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": "-- Grafana --",
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "editable": true,
+      "gnetId": null,
+      "graphTooltip": 0,
+      "id": null,
+      "iteration": 1541099197839,
+      "links": [],
+      "panels": [
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 54,
+          "panels": [],
+          "repeat": null,
+          "title": "Portworx Cluster \"[[Cluster]]\"",
+          "type": "row"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": true,
+          "colors": [
+            "#fce2de",
+            "#eab839",
+            "#bf1b00"
+          ],
+          "datasource": "prometheus",
+          "format": "percent",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": true,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 0,
+            "y": 1
+          },
+          "id": 56,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "sum(px_cluster_disk_utilized_bytes{cluster=~\"[[Cluster]]\"})/sum(px_cluster_disk_total_bytes{cluster=~\"[[Cluster]]\"})",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "thresholds": "80,90",
+          "title": "Usage Meter",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "total"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "datasource": "prometheus",
+          "format": "bytes",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 4,
+            "y": 1
+          },
+          "id": 63,
+          "interval": null,
+          "links": [
+            {
+              "dashUri": "db/portworx-volume-dashboard",
+              "dashboard": "Portworx Volume Dashboard",
+              "includeVars": true,
+              "keepTime": true,
+              "targetBlank": true,
+              "title": "Portworx Volume Dashboard",
+              "type": "dashboard"
+            }
+          ],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "sum(px_cluster_disk_utilized_bytes{cluster=~\"[[Cluster]]\"})",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "thresholds": "",
+          "title": "Capacity Used",
+          "transparent": false,
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "datasource": "prometheus",
+          "format": "percent",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 8,
+            "y": 1
+          },
+          "id": 61,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "avg(px_cluster_cpu_percent{cluster=~\"[[Cluster]]\"})",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "thresholds": "",
+          "title": "Avg. Cluster CPU",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "datasource": "prometheus",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 2,
+            "w": 4,
+            "x": 12,
+            "y": 1
+          },
+          "id": 62,
+          "interval": null,
+          "links": [
+            {
+              "dashUri": "db/portworx-node-dashboard",
+              "dashboard": "Portworx Node Dashboard",
+              "includeVars": true,
+              "keepTime": true,
+              "targetBlank": true,
+              "title": "Portworx Node Dashboard",
+              "type": "dashboard"
+            }
+          ],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "min(px_cluster_status_cluster_size{cluster=~\"[[Cluster]]\"}) ",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "thresholds": "",
+          "title": "# Nodes (total)",
+          "transparent": false,
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "#299c46",
+            "#629e51",
+            "#d44a3a"
+          ],
+          "datasource": "prometheus",
+          "format": "short",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 16,
+            "y": 1
+          },
+          "hideTimeOverride": true,
+          "id": 81,
+          "interval": "15s",
+          "links": [],
+          "mappingType": 2,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "2",
+              "text": "Quorum Unhealthy",
+              "to": "1000"
+            },
+            {
+              "from": "0",
+              "text": "Quorum Healthy",
+              "to": "1.99"
+            }
+          ],
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "min(px_cluster_status_cluster_size{cluster=~\"[[Cluster]]\"})/sum(px_cluster_status_cluster_quorum{cluster=~\"[[Cluster]]\"})",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "thresholds": "1.1,1.9",
+          "timeFrom": "1m",
+          "title": "Quorum",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "2"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "datasource": "prometheus",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 2,
+            "w": 4,
+            "x": 20,
+            "y": 1
+          },
+          "id": 85,
+          "interval": null,
+          "links": [
+            {
+              "dashUri": "db/portworx-node-dashboard",
+              "dashboard": "Portworx Node Dashboard",
+              "includeVars": true,
+              "keepTime": true,
+              "targetBlank": true,
+              "title": "Portworx Node Dashboard",
+              "type": "dashboard"
+            }
+          ],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "min(px_cluster_status_nodes_online{cluster=~\"[[Cluster]]\"}) ",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "thresholds": "",
+          "title": "# Nodes online",
+          "transparent": false,
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "datasource": "prometheus",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 2,
+            "w": 4,
+            "x": 12,
+            "y": 3
+          },
+          "id": 83,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "min(px_cluster_status_storage_nodes_online{cluster=~\"[[Cluster]]\"})",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "refId": "A"
+            }
+          ],
+          "thresholds": "",
+          "title": "Storage Providers",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "datasource": "prometheus",
+          "format": "short",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 2,
+            "w": 4,
+            "x": 20,
+            "y": 3
+          },
+          "id": 84,
+          "interval": null,
+          "links": [],
+          "mappingType": 2,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "0",
+              "text": "All members online",
+              "to": "0"
+            },
+            {
+              "from": "1",
+              "text": "Members offline",
+              "to": "1"
+            },
+            {
+              "from": "2",
+              "text": "Members offline",
+              "to": "1000"
+            }
+          ],
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "min(px_cluster_status_cluster_size{cluster=\"[[Cluster]]\"})-min(px_cluster_status_storage_nodes_online{cluster=\"[[Cluster]]\"})",
+              "format": "time_series",
+              "instant": false,
+              "intervalFactor": 1,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "thresholds": "0.5,1",
+          "title": "",
+          "type": "singlestat",
+          "valueFontSize": "50%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "",
+              "value": "0"
+            },
+            {
+              "op": "=",
+              "text": "",
+              "value": ""
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cards": {
+            "cardPadding": null,
+            "cardRound": null
+          },
+          "color": {
+            "cardColor": "#b4ff00",
+            "colorScale": "sqrt",
+            "colorScheme": "interpolateOranges",
+            "exponent": 0.5,
+            "mode": "spectrum"
+          },
+          "dataFormat": "timeseries",
+          "datasource": "prometheus",
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 5
+          },
+          "heatmap": {},
+          "highlightCards": true,
+          "id": 78,
+          "legend": {
+            "show": true
+          },
+          "links": [
+            {
+              "dashUri": "db/portworx-node-dashboard",
+              "dashboard": "Portworx Node Dashboard",
+              "includeVars": true,
+              "keepTime": true,
+              "targetBlank": true,
+              "title": "Portworx Node Dashboard",
+              "type": "dashboard"
+            }
+          ],
+          "targets": [
+            {
+              "expr": "px_cluster_cpu_percent{cluster =~ \"[[Cluster]]\"}",
+              "format": "time_series",
+              "interval": "5m",
+              "intervalFactor": 1,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "CPU utilization heat map",
+          "tooltip": {
+            "show": true,
+            "showHistogram": true
+          },
+          "transparent": false,
+          "type": "heatmap",
+          "xAxis": {
+            "show": true
+          },
+          "xBucketNumber": null,
+          "xBucketSize": null,
+          "yAxis": {
+            "decimals": null,
+            "format": "percent",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true,
+            "splitFactor": null
+          },
+          "yBucketNumber": null,
+          "yBucketSize": null
+        },
+        {
+          "cards": {
+            "cardPadding": null,
+            "cardRound": null
+          },
+          "color": {
+            "cardColor": "#b4ff00",
+            "colorScale": "sqrt",
+            "colorScheme": "interpolateOranges",
+            "exponent": 0.5,
+            "mode": "spectrum"
+          },
+          "dataFormat": "timeseries",
+          "datasource": "prometheus",
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 5
+          },
+          "heatmap": {},
+          "highlightCards": true,
+          "id": 79,
+          "legend": {
+            "show": true
+          },
+          "links": [
+            {
+              "dashUri": "db/portworx-node-dashboard",
+              "dashboard": "Portworx Node Dashboard",
+              "includeVars": true,
+              "keepTime": true,
+              "targetBlank": true,
+              "title": "Node Drilldown",
+              "type": "dashboard"
+            }
+          ],
+          "repeat": null,
+          "repeatDirection": "h",
+          "targets": [
+            {
+              "expr": "px_cluster_memory_utilized_percent{cluster =~ \"[[Cluster]]\"}",
+              "format": "time_series",
+              "interval": "5m",
+              "intervalFactor": 1,
+              "legendFormat": "{{cluster}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Memory utilization heat map",
+          "tooltip": {
+            "show": true,
+            "showHistogram": true
+          },
+          "type": "heatmap",
+          "xAxis": {
+            "show": true
+          },
+          "xBucketNumber": null,
+          "xBucketSize": null,
+          "yAxis": {
+            "decimals": null,
+            "format": "percent",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true,
+            "splitFactor": null
+          },
+          "yBucketNumber": null,
+          "yBucketSize": null
+        }
+      ],
+      "refresh": "30s",
+      "schemaVersion": 16,
+      "style": "dark",
+      "tags": [],
+      "templating": {
+        "list": [
+          {
+            "allValue": null,
+            "current": {},
+            "datasource": "prometheus",
+            "hide": 1,
+            "includeAll": false,
+            "label": "",
+            "multi": false,
+            "name": "Cluster",
+            "options": [],
+            "query": "px_cluster_cpu_percent",
+            "refresh": 1,
+            "regex": "/.*cluster=\"([^\"]*).*/",
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          }
+        ]
+      },
+      "time": {
+        "from": "now-3h",
+        "to": "now"
+      },
+      "timepicker": {
+        "refresh_intervals": [
+          "5s",
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h",
+          "2h",
+          "1d"
+        ],
+        "time_options": [
+          "5m",
+          "15m",
+          "1h",
+          "6h",
+          "12h",
+          "24h",
+          "2d",
+          "7d",
+          "30d"
+        ]
+      },
+      "timezone": "",
+      "title": "Portworx Cluster Dashboard",
+      "uid": "xLgt8oTik",
+      "version": 6
+    }	

--- a/charts/portworx/files/portworx-etcd-dashboard.json
+++ b/charts/portworx/files/portworx-etcd-dashboard.json
@@ -1,4 +1,4 @@
-{
+    {
       "__inputs": [
         {
           "name": "DS_PROMETHEUS",

--- a/charts/portworx/files/portworx-node-dashboard.json
+++ b/charts/portworx/files/portworx-node-dashboard.json
@@ -1,4 +1,4 @@
-{
+    {
       "__inputs": [
         {
           "name": "DS_PROMETHEUS",

--- a/charts/portworx/files/portworx-volume-dashboard.json
+++ b/charts/portworx/files/portworx-volume-dashboard.json
@@ -1,4 +1,4 @@
-{
+    {
       "__inputs": [
         {
           "name": "DS_PROMETHEUS",

--- a/charts/portworx/templates/portworx-controller.yaml
+++ b/charts/portworx/templates/portworx-controller.yaml
@@ -1,5 +1,5 @@
 {{- $AKSorEKSInstall := or .Values.AKSInstall  .Values.EKSInstall  }}
-{{- if or ((.Values.openshiftInstall) and (eq .Values.openshiftInstall true)) ($AKSorEKSInstall) ((.Capabilities.KubeVersion.GitVersion | regexMatch "gke")) }}
+{{- if or (and (.Values.openshiftInstall) (eq .Values.openshiftInstall true)) ($AKSorEKSInstall) ((.Capabilities.KubeVersion.GitVersion | regexMatch "gke")) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/portworx/templates/portworx-csi.yaml
+++ b/charts/portworx/templates/portworx-csi.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.csi) and (eq .Values.csi true)}}
+{{- if (and (.Values.csi) (eq .Values.csi true))}}
 {{- $customRegistryURL := .Values.customRegistryURL | default "none" }}
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/portworx/templates/portworx-ds.yaml
+++ b/charts/portworx/templates/portworx-ds.yaml
@@ -66,10 +66,10 @@ spec:
                 operator:  {{ template "px.affinityPxEnabledOperator" . }}
                 values:
                 - {{ template "px.affinityPxEnabledValue" . }}
-              {{- if (.Values.openshiftInstall) and (eq .Values.openshiftInstall true)}}
+              {{- if (and (.Values.openshiftInstall) (eq .Values.openshiftInstall true))}}
               - key: openshift-infra
                 operator: DoesNotExist
-              {{- else if (not .Values.deployOnMaster) or (eq .Values.deployOnMaster false)}}
+              {{- else if (or (not .Values.deployOnMaster) (eq .Values.deployOnMaster false))}}
               - key: node-role.kubernetes.io/master
                 operator: DoesNotExist
               {{- end }}

--- a/charts/portworx/templates/portworx-lighthouse.yaml
+++ b/charts/portworx/templates/portworx-lighthouse.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.lighthouse) and (eq .Values.lighthouse true) -}}
+{{- if (and (.Values.lighthouse) (eq .Values.lighthouse true)) -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/portworx/templates/portworx-monitor.yaml
+++ b/charts/portworx/templates/portworx-monitor.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.monitoring) and (eq .Values.monitoring true) -}}
+{{- if (and (.Values.monitoring) (eq .Values.monitoring true)) -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -37,6 +37,8 @@ rules:
       - prometheuses/finalizers
       - servicemonitors
       - prometheusrules
+      - podmonitors
+      - thanosrulers
     verbs: ["*"]
   - apiGroups:
       - apps
@@ -72,6 +74,12 @@ metadata:
   name: prometheus-operator
   namespace: kube-system
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus
+  namespace: kube-system
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -93,7 +101,7 @@ spec:
         - args:
             - --kubelet-service=kube-system/kubelet
             - --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
-          image: quay.io/coreos/prometheus-operator:v0.29.0
+          image: quay.io/coreos/prometheus-operator:v0.36.0
           name: prometheus-operator
           ports:
             - containerPort: 8080
@@ -137,7 +145,7 @@ metadata:
   labels:
     alertmanager: portworx
 spec:
-  replicas: 3
+  replicas: 3  
 ---
 apiVersion: v1
 kind: Service
@@ -145,7 +153,7 @@ metadata:
   name: alertmanager-portworx
   namespace: kube-system
 spec:
-  type: NodePort
+  type: ClusterIP
   ports:
     - name: web
       port: 9093
@@ -237,7 +245,7 @@ spec:
         severity: warning
     - alert: PortworxStorageNodeDown
       annotations:
-        description: Portworx Storage Node has been offline for more than 5 minutes.
+        description: Portworx Storage Node has been offline for more than 5 minutes
         summary: Portworx Storage Node is Offline.
       expr: max(px_cluster_status_nodes_storage_down) > 0
       for: 5m
@@ -264,12 +272,6 @@ spec:
       labels:
         issue: Portworx cluster member(s) is(are) down.
         severity: critical
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: prometheus
-  namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -321,19 +323,10 @@ spec:
   serviceMonitorSelector:
     matchLabels:
       name: portworx-prometheus-sm
-    namespaceSelector:
-      matchNames:
-        - kube-system
-    resources:
-      requests:
-        memory: 400Mi
   ruleSelector:
     matchLabels:
       role: prometheus-portworx-rulefiles
       prometheus: portworx
-    namespaceSelector:
-      matchNames:
-        - kube-system
 ---
 apiVersion: v1
 kind: Service
@@ -341,7 +334,7 @@ metadata:
   name: prometheus
   namespace: kube-system
 spec:
-  type: NodePort
+  type: ClusterIP
   ports:
     - name: web
       port: 9090
@@ -452,7 +445,7 @@ metadata:
   labels:
     app: grafana
 spec:
-  type: NodePort
+  type: ClusterIP
   ports:
     - port: 3000
   selector:
@@ -466,17 +459,17 @@ metadata:
   labels:
     app: grafana
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app: grafana
-  replicas: 1
   template:
     metadata:
       labels:
         app: grafana
     spec:
       containers:
-        - image: grafana/grafana:5.0.4
+        - image: grafana/grafana:5.3.3
           name: grafana
           imagePullPolicy: IfNotPresent
           resources:

--- a/charts/portworx/templates/portworx-monitor.yaml
+++ b/charts/portworx/templates/portworx-monitor.yaml
@@ -469,7 +469,7 @@ spec:
         app: grafana
     spec:
       containers:
-        - image: grafana/grafana:5.3.3
+        - image: grafana/grafana:7.1.3
           name: grafana
           imagePullPolicy: IfNotPresent
           resources:

--- a/charts/portworx/templates/portworx-stork.yaml
+++ b/charts/portworx/templates/portworx-stork.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.stork) and (eq .Values.stork true)}}
+{{- if (and (.Values.stork) (eq .Values.stork true))}}
 {{- $isCoreOS := .Values.isTargetOSCoreOS | default false }}
 {{- $customRegistryURL := .Values.customRegistryURL | default "none" }}
 {{- $registrySecret := .Values.registrySecret | default "none" }}


### PR DESCRIPTION

**What this PR does / why we need it**:
This PR fixes 2 issues:
1. Update monitoring template to match latest generated by Portworx spec generator, more specifically updated Prometheus version to run on latest k8s releases and updated latest Grafana dashboards
2. Changed template to use `prefix` AND instead of `infix` so it can deployed with helm version 3 (this is because of GO 1.14 templates)

**Which issue(s) this PR fixes** (optional)
Closes #158

**Special notes for your reviewer**:

