### PR TITLE
add watch/list configmap permissions for portworx-controller

### DIFF
--- a/charts/portworx/templates/portworx-controller.yaml
+++ b/charts/portworx/templates/portworx-controller.yaml
@@ -46,7 +46,7 @@ rules:
   verbs: ["get", "create"]
 - apiGroups: [""]
   resources: ["configmaps"]
-  verbs: ["get", "create", "update"]
+  verbs: ["get", "create", "update", "watch", "list"]
 - apiGroups: [""]
   resources: ["serviceaccounts/token"]
   verbs: ["get", "create", "update"]


### PR DESCRIPTION
Signed-off-by: trierra <oksana@portworx.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

Portworx-controller unable to list and watch configmap

**Which issue(s) this PR fixes** (optional)
Closes #174 

**Special notes for your reviewer**:

