### PR TITLE
Add missing persistentvolume-expander

### DIFF
--- a/charts/portworx/templates/portworx-controller.yaml
+++ b/charts/portworx/templates/portworx-controller.yaml
@@ -105,7 +105,7 @@ spec:
         - kube-controller-manager
         - --leader-elect=true
         - --address=0.0.0.0
-        - --controllers=persistentvolume-binder
+        - --controllers=persistentvolume-binder,persistentvolume-expander
         - --use-service-account-credentials=true
         - --leader-elect-resource-lock=configmaps
         image: "{{ template "px.getk8sImages" . }}/kube-controller-manager-amd64:{{ template "px.kubernetesVersion" . }}"


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds the missing "persistentvolume-expander" controller to portworx-pvc-controller deployment definition.

This brings the Helm chart inline with yaml generated by PX Central.

Without this in place, Portworx volumes are unable to be expanded from the PVC request definition; you get the following error when describing the PVC if you try:

Error expanding volume "my-namespace-name/my-pvc-name" of plugin "kubernetes.io/portworx-volume": Get http://x.x.x.x:9001/v1/osd-volumes/versions: dial tcp x.x.x.x:9001: i/o timeout

This change fixes that.