### PR TITLE
Adding option to specify dedicated kvdb device

### DIFF
--- a/charts/portworx/templates/portworx-ds.yaml
+++ b/charts/portworx/templates/portworx-ds.yaml
@@ -17,6 +17,7 @@
 
 {{- $pksInstall := .Values.pksInstall | default false }}
 {{- $internalKVDB := .Values.internalKVDB | default false }}
+{{- $kvdbDevice := .Values.kvdbDevice | default "none" }}
 {{- $csi := .Values.csi | default false }}
 
 {{- $etcdCredentials := .Values.etcd.credentials | default "none:none" }}
@@ -109,6 +110,9 @@ spec:
 
               {{- if eq $internalKVDB true }}
               "-b",
+                {{- if ne $kvdbDevice "none" }}
+                "-kvdb_dev", "{{ $kvdbDevice }}",
+                {{- end -}}
               {{- end -}}
 
               {{- if ne $journalDevice "none" }}

--- a/charts/portworx/values.yaml
+++ b/charts/portworx/values.yaml
@@ -39,6 +39,7 @@ deployOnMaster:  false                # For POC only
 csi: false                            # Enable CSI
 
 internalKVDB: false                   # internal KVDB
+kvdbDevice: none                      # specify a separate device to store KVDB data, only used when internalKVDB is set to true
 
 etcd:
   credentials: none:none              # Username and password for ETCD authentication in the form user:password


### PR DESCRIPTION

**What this PR does / why we need it**:
This PR adds a new optional parameter to specify a dedicated kvdb device when using internal KVDB: kvdbDevice.
This was a requirement from Mavenir as they are using helm to deploy Portworx and wants to specify a dedicated kvdb device for the internal KVDB.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**: 
I tested this in on-prem and EKS clusters.

