### PR TITLE
Mounting empty directory for /.keycloak

### DIFF
--- a/charts/px-backup/templates/px-central-oidc/pxcentral-keycloak.yaml
+++ b/charts/px-backup/templates/px-central-oidc/pxcentral-keycloak.yaml
@@ -492,6 +492,8 @@ spec:
               readOnly: true
             - name: theme
               mountPath: /opt/jboss/keycloak/themes/portworx
+            - name: keycloakDir
+              mountPath: /.keycloak
             {{- if .Values.caCertsSecretName }}
             - name: ssl-cert-dir
               readOnly: true
@@ -541,6 +543,8 @@ spec:
         - name: theme
           emptyDir: {}
         {{- end }}
+        - emptyDir: {}
+          name: keycloakDir
   {{- if eq $externalPersistentStorageEnabled true }}
   volumeClaimTemplates:
     - metadata:


### PR DESCRIPTION

 Signed off: Diptiranjan
  
This fix is required for cases where creating /.keycloak directory is failing.

