### PR TITLE
Changing the keycloakDir var name to lower case to avoid the deployment error.

### DIFF
--- a/charts/px-backup/templates/px-central-oidc/pxcentral-keycloak.yaml
+++ b/charts/px-backup/templates/px-central-oidc/pxcentral-keycloak.yaml
@@ -492,7 +492,7 @@ spec:
               readOnly: true
             - name: theme
               mountPath: /opt/jboss/keycloak/themes/portworx
-            - name: keycloakDir
+            - name: keycloakdir
               mountPath: /.keycloak
             {{- if .Values.caCertsSecretName }}
             - name: ssl-cert-dir
@@ -544,7 +544,7 @@ spec:
           emptyDir: {}
         {{- end }}
         - emptyDir: {}
-          name: keycloakDir
+          name: keycloakdir
   {{- if eq $externalPersistentStorageEnabled true }}
   volumeClaimTemplates:
     - metadata:


### PR DESCRIPTION

  Signed off - Diptiranjan
  Fix for failing stateful set deployment because the name is not standard to DNS-1123 label naming format.
