### PR TITLE
Tune in ETCD_SNAPSHOT_COUNT to 10000 for lower memory usage.

### DIFF
--- a/charts/px-backup/templates/px-backup/pxcentral-etcd.yaml
+++ b/charts/px-backup/templates/px-backup/pxcentral-etcd.yaml
@@ -297,6 +297,8 @@ spec:
               value: "periodic"
             - name: ETCD_QUOTA_BACKEND_BYTES
               value: "8589934592"
+            - name: ETCD_SNAPSHOT_COUNT
+              value: "10000"
           ports:
             - name: client
               containerPort: 2379


### PR DESCRIPTION
Signed off - Diptiranjan

Lowering the memory usage will prevent the pod from getting exited with OOM.

