### PR TITLE
helm param to make px-backup-ui, pxcentral-grafana and pxcentral-cortex-nginx service configurable with different service type.

### DIFF
--- a/px-central/templates/px-lighthouse/px-central-ui/pxcentral-ui.yaml
+++ b/px-central/templates/px-lighthouse/px-central-ui/pxcentral-ui.yaml
@@ -567,7 +567,7 @@ metadata:
     app.kubernetes.io/component: pxcentral-frontend
 {{- include "px-central.labels" . | nindent 4 }}
 spec:
-  type: LoadBalancer
+  type: {{ .Values.service.pxBackupUIServiceType }}
   selector:
     run: pxcentral-frontend
   ports:

--- a/px-central/templates/px-lighthouse/px-monitor-svc.yaml
+++ b/px-central/templates/px-lighthouse/px-monitor-svc.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: pxcentral-grafana
 {{- include "px-central.labels" . | nindent 4 }}
 spec:
-  type: NodePort
+  type: {{ .Values.service.grafanaServiceType }}
   ports:
     - port: 3000
   selector:
@@ -25,7 +25,7 @@ metadata:
     cortex: nginx
 {{- include "px-central.labels" . | nindent 4 }}
 spec:
-  type: NodePort
+  type: {{ .Values.service.cortexNginxServiceType }}
   ports:
   - name: http
     port: 80

--- a/px-central/values.yaml
+++ b/px-central/values.yaml
@@ -65,6 +65,11 @@ pxmonitor:
   oidcClientSecret: ""
   nodeAffinityLabel:
 
+service:
+  pxBackupUIServiceType: "LoadBalancer"
+  grafanaServiceType: "NodePort"
+  cortexNginxServiceType: "NodePort"
+
 ## Memory settings: These are calculated automatically unless specified otherwise
 ## To run on environments with little resources (<= 8GB), tune your heap settings:
 ## maxHeapSize:


### PR DESCRIPTION
Signed off : Diptiranjan
Default values are as follows 
    px-backup-ui - LoadBalancer
    pxcentral-grafana - NodePort
    pxcentral-cortex-nginx - NodePort