### PR TITLE
[OC-589] Add missing namespaces for license server and monitor charts

### DIFF
--- a/charts/px-license-server/templates/license-server-ha-setup.yaml
+++ b/charts/px-license-server/templates/license-server-ha-setup.yaml
@@ -13,6 +13,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: pxcentral-license-server
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: pxcentral-license-server
 {{- include "px-license-server.labels" . | nindent 4 }}
@@ -52,6 +53,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: pxcentral-license-server
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: pxcentral-license-server
 {{- include "px-license-server.labels" . | nindent 4 }}

--- a/charts/px-monitor/templates/cortex/cortex-sts.yaml
+++ b/charts/px-monitor/templates/cortex/cortex-sts.yaml
@@ -299,6 +299,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: pxcentral-cortex-consul
+  namespace: {{ .Release.Namespace }}
   labels:
     cortex: consul
 {{- include "px-monitor.labels" . | nindent 4 }}

--- a/charts/px-monitor/templates/prometheus/prometheus.yaml
+++ b/charts/px-monitor/templates/prometheus/prometheus.yaml
@@ -24,6 +24,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: pxcentral-prometheus
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: pxcentral-prometheus
 {{- include "px-monitor.labels" . | nindent 4 }}
@@ -46,6 +47,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: pxcentral-prometheus
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: pxcentral-prometheus
 {{- include "px-monitor.labels" . | nindent 4 }}
@@ -97,6 +99,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: pxcentral-prometheus-operator
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: pxcentral-prometheus
 {{- include "px-monitor.labels" . | nindent 4 }}
@@ -153,6 +156,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: pxcentral-prometheus-operator
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: pxcentral-prometheus
 {{- include "px-monitor.labels" . | nindent 4 }}

--- a/charts/px-monitor/templates/px-monitor-post-install-setup.yaml
+++ b/charts/px-monitor/templates/px-monitor-post-install-setup.yaml
@@ -13,6 +13,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: pxcentral-monitor-post-install-setup
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: pxcentral-monitor-post-install-setup
 {{- include "px-monitor.labels" . | nindent 4 }}
@@ -52,6 +53,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: pxcentral-monitor-post-install-setup
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: pxcentral-monitor-post-install-setup
 {{- include "px-monitor.labels" . | nindent 4 }}


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: When installed by torpedo, Role, RoleBinding and StatefulSet without namespace will be created in `default` namespace

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**: verified by local torpedo test run

