### PR TITLE
[PB-1118]: Changes for using mongodb as datastore for px-backup.

### DIFF
--- a/px-central/templates/px-backup/pxcentral-backup.yaml
+++ b/px-central/templates/px-backup/pxcentral-backup.yaml
@@ -1,5 +1,6 @@
 {{/* Setting defaults if they are omitted. */}}
 {{- $pxBackupEnabled := .Values.pxbackup.enabled | default false }}
+{{- $mongodbEnabled := eq .Values.pxbackup.datastore "mongodb" }}
 {{- if eq $pxBackupEnabled true }}
 apiVersion: v1
 kind: ServiceAccount
@@ -122,6 +123,10 @@ spec:
           value: {{ .Release.Namespace }}
         - name: PX_BACKUP_DEFAULT_ORG
           value: {{ .Values.pxbackup.orgName }}
+        {{- if eq $mongodbEnabled true }}
+        - name: PX_BACKUP_DEFAULT_DATASTORE
+          value: mongodb
+        {{- end}}
         {{- if .Values.caCertsSecretName }}
         - name: SSL_CERT_DIR
           value: /tmp/certs
@@ -155,7 +160,11 @@ spec:
         command:
         - /px-backup
         - start
+        {{- if eq $mongodbEnabled true }}
+        - --datastoreEndpoints=mongodb://pxbackup:Password1@pxc-backup-mongodb-0.pxc-backup-mongodb-headless:27017,pxc-backup-mongodb-1.pxc-backup-mongodb-headless:27017,pxc-backup-mongodb-2.pxc-backup-mongodb-headless:27017/?authSource=px-backup&replicaSet=rs0
+        {{- else }}
         - --datastoreEndpoints=etcd:http://pxc-backup-etcd-0.pxc-backup-etcd-headless:2379,etcd:http://pxc-backup-etcd-1.pxc-backup-etcd-headless:2379,etcd:http://pxc-backup-etcd-2.pxc-backup-etcd-headless:2379
+        {{- end }}
       {{- if .Values.caCertsSecretName }}
       volumes:
         - name: ssl-cert-dir

--- a/px-central/templates/px-backup/pxcentral-mongodb.yaml
+++ b/px-central/templates/px-backup/pxcentral-mongodb.yaml
@@ -1,0 +1,253 @@
+{{/* Setting defaults if they are omitted. */}}
+{{- $pxBackupEnabled := .Values.pxbackup.enabled | default false }}
+{{- $mongodbEnabled := eq .Values.pxbackup.datastore "mongodb" }}
+{{- $externalPersistentStorageEnabled := .Values.persistentStorage.enabled | default false }}
+{{- $isOpenshiftCluster := .Capabilities.APIVersions.Has "apps.openshift.io/v1" -}}
+{{- if and (eq $pxBackupEnabled true) (eq $mongodbEnabled true) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pxc-backup-mongodb-scripts
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: pxc-backup-mongodb
+  {{- include "px-central.labels" . | nindent 4 }}
+data:
+  setup.sh: |-
+    #!/bin/bash
+
+    echo "Advertised Hostname: $MONGODB_ADVERTISED_HOSTNAME"
+
+    if [[ "$MY_POD_NAME" = "pxc-backup-mongodb-0" ]]; then
+        echo "Pod name matches initial primary pod name, configuring node as a primary"
+        export MONGODB_REPLICA_SET_MODE="primary"
+    else
+        echo "Pod name doesn't match initial primary pod name, configuring node as a secondary"
+        export MONGODB_REPLICA_SET_MODE="secondary"
+        export MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD="$MONGODB_ROOT_PASSWORD"
+        export MONGODB_INITIAL_PRIMARY_PORT_NUMBER="$MONGODB_PORT_NUMBER"
+        export MONGODB_ROOT_PASSWORD="" MONGODB_USERNAME="" MONGODB_DATABASE="" MONGODB_PASSWORD=""
+    fi
+
+    exec /opt/bitnami/scripts/mongodb/entrypoint.sh /opt/bitnami/scripts/mongodb/run.sh
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pxc-backup-mongodb-headless
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: pxc-backup-mongodb
+{{- include "px-central.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - name: mongodb
+      port: 27017
+      targetPort: mongodb
+  selector:
+    app.kubernetes.io/component: pxc-backup-mongodb
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/component: pxc-backup-mongodb
+{{- include "px-central.labels" . | nindent 4 }}
+  name: pxc-backup-mongodb
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+stringData:
+  mongodb-root-password: "pxcentral"
+  mongodb-password: "Password1"
+  mongodb-replica-set-key: "pxbackup"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pxc-backup-mongodb
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: pxc-backup-mongodb
+{{- include "px-central.labels" . | nindent 4 }}
+secrets:
+  - name: pxc-backup-mongodb
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: pxc-backup-mongodb
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: pxc-backup-mongodb
+{{- include "px-central.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{.Release.Name }}
+      app.kubernetes.io/instance: {{.Release.Name }}
+      app.kubernetes.io/managed-by: {{.Release.Service }}
+      app.kubernetes.io/component: pxc-backup-mongodb
+  serviceName: pxc-backup-mongodb-headless
+  podManagementPolicy: OrderedReady
+  replicas: 3
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{.Release.Name }}
+        app.kubernetes.io/instance: {{.Release.Name }}
+        app.kubernetes.io/managed-by: {{.Release.Service }}
+        app.kubernetes.io/component: pxc-backup-mongodb
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              {{- if .Values.pxbackup.nodeAffinityLabel }}
+              - key: {{ .Values.pxbackup.nodeAffinityLabel }}
+                operator: Exists
+              {{- else }}
+              - key: pxbackup/enabled
+                operator: NotIn
+                values:
+                - "false"
+              {{- end }}
+      {{- if eq .Values.storkRequired true }}
+      schedulerName: stork
+      {{- end }}
+      {{- if .Values.images.pullSecrets }}
+      imagePullSecrets:
+        {{- range $sec := .Values.images.pullSecrets }}
+        - name: {{ $sec | quote }}
+        {{- end }}
+      {{- end }}
+      serviceAccountName: pxc-backup-mongodb
+      {{- if $isOpenshiftCluster}}
+      {{- else }}
+      securityContext:
+{{ toYaml .Values.securityContext | indent 8 }}
+      {{- end }}
+      containers:
+        - name: mongodb
+          image: {{ printf "%s/%s/%s:%s" .Values.images.mongodbImage.registry .Values.images.mongodbImage.repo .Values.images.mongodbImage.imageName .Values.images.mongodbImage.tag }}
+          imagePullPolicy: {{ .Values.images.pullPolicy }}
+          command:
+            - /scripts/setup.sh
+          env:
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: K8S_SERVICE_NAME
+              value: pxc-backup-mongodb-headless
+            - name: MONGODB_INITIAL_PRIMARY_HOST
+              value: pxc-backup-mongodb-0.$(K8S_SERVICE_NAME)
+            - name: MONGODB_REPLICA_SET_NAME
+              value: rs0
+            - name: MONGODB_ADVERTISED_HOSTNAME
+              value: $(MY_POD_NAME).$(K8S_SERVICE_NAME)
+            - name: SHARED_FILE
+              value: "/shared/info.txt"
+            - name: MONGODB_USERNAME
+              value: pxbackup
+            - name: MONGODB_DATABASE
+              value: px-backup
+            - name: MONGODB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: mongodb-password
+                  name: pxc-backup-mongodb
+            - name: MONGODB_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: mongodb-root-password
+                  name: pxc-backup-mongodb
+            - name: MONGODB_REPLICA_SET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: mongodb-replica-set-key
+                  name: pxc-backup-mongodb
+            - name: ALLOW_EMPTY_PASSWORD
+              value: "no"
+            - name: MONGODB_SYSTEM_LOG_VERBOSITY
+              value: "0"
+            - name: MONGODB_DISABLE_SYSTEM_LOG
+              value: "no"
+            - name: MONGODB_ENABLE_IPV6
+              value: "no"
+            - name: MONGODB_ENABLE_DIRECTORY_PER_DB
+              value: "no"
+          ports:
+            - containerPort: 27017
+              name: mongodb
+              protocol: TCP
+          livenessProbe:
+            exec:
+              command:
+              - mongo
+              - --disableImplicitSessions
+              - --eval
+              - db.adminCommand('ping')
+            failureThreshold: 6
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+              - bash
+              - -ec
+              - |
+                mongo --disableImplicitSessions $TLS_OPTIONS --eval 'db.hello().isWritablePrimary || db.hello().secondary' | grep -q 'true'
+            failureThreshold: 6
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          volumeMounts:
+            - mountPath: /bitnami/mongodb
+              name: pxc-mongodb-data
+            - mountPath: /scripts/setup.sh
+              name: scripts
+              subPath: setup.sh
+      volumes:
+        - name: scripts
+          configMap:
+            defaultMode: 493
+            name: pxc-backup-mongodb-scripts
+        {{- if eq $externalPersistentStorageEnabled false }}
+        - name: pxc-mongodb-data
+          emptyDir: {}
+        {{- end }}
+  {{- if eq $externalPersistentStorageEnabled true }}
+  volumeClaimTemplates:
+    - metadata:
+        name: pxc-mongodb-data
+      spec:
+        accessModes:
+          - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: {{ .Values.persistentStorage.etcdVolumeSize }}
+        {{- if .Values.persistentStorage.storageClassName }}
+        storageClassName: {{ .Values.persistentStorage.storageClassName }}
+        {{- end }}
+  {{- end }}
+{{- end -}}

--- a/px-central/values.yaml
+++ b/px-central/values.yaml
@@ -43,7 +43,7 @@ pxbackup:
   orgName: default
   callHome: true
   nodeAffinityLabel:
-  datastore: mongodb
+  datastore: etcd
 
 pxlicenseserver:
   enabled: false

--- a/px-central/values.yaml
+++ b/px-central/values.yaml
@@ -43,6 +43,7 @@ pxbackup:
   orgName: default
   callHome: true
   nodeAffinityLabel:
+  datastore: mongodb
 
 pxlicenseserver:
   enabled: false
@@ -139,6 +140,11 @@ images:
     repo: bitnami
     imageName: etcd
     tag: 3.4.13-debian-10-r22
+  mongodbImage:
+    registry: docker.io
+    repo: bitnami
+    imageName: mongodb
+    tag: 4.4.4-debian-10-r30
   keycloakBackendImage:
     registry: docker.io
     repo: bitnami


### PR DESCRIPTION
Signed-off By: Diptiranjan

1. Installs of mongodb with 3 replicasets.
2. Both etcd and mongodb sts will be present and the default will be mongodb.

Tests:
1. Installation with px-backup enabled and created backups on a cluster.
2. Pod delete and verifying data.
3. Scaling down to 0 replicas and scale up to 3.

