### PR TITLE
[OC-673] : oidc-client-secret to be detected automatically for grafana config during px-monitor install.

### DIFF
--- a/px-central/templates/px-lighthouse/pxcentral-post-install-hook.yaml
+++ b/px-central/templates/px-lighthouse/pxcentral-post-install-hook.yaml
@@ -54,7 +54,7 @@ spec:
             {{- else }}
             value: "upgrade"
             {{- end }}
-        command: ["python",  "/pxcentral-post-install/pxc-post-setup.py"]
+        command: ["python", "-u", "/pxcentral-post-install/pxc-post-setup.py"]
       {{- if .Values.images.pullSecrets }}
       imagePullSecrets:
         {{- range $sec := .Values.images.pullSecrets }}

--- a/px-central/templates/px-monitor/grafana/grafana-config.yaml
+++ b/px-central/templates/px-monitor/grafana/grafana-config.yaml
@@ -17,12 +17,8 @@ data:
     auto_assign_org_role = Admin
 
     [server]
-    domain = {{ .Values.pxmonitor.pxCentralEndpoint }}
-    {{- if eq $sslEnabled true }}
-    root_url = {{ printf "https://%s/grafana" .Values.pxmonitor.pxCentralEndpoint}}
-    {{- else }}
-    root_url = {{ printf "http://%s/grafana" .Values.pxmonitor.pxCentralEndpoint}}
-    {{- end }}
+    domain = {{ .Values.pxmonitor.pxCentralEndpoint }} 
+    root_url = "%(protocol)s://%(domain)s/grafana"
     enforce_domain = false
 
     [auth.basic]
@@ -33,7 +29,7 @@ data:
     enabled= true
     client_id= {{ .Values.pxmonitor.oidcClientID }}
     name = "OIDC"
-    client_secret = 
+    client_secret = ""
     {{- if eq $sslEnabled true }}
     auth_url = {{ printf "https://%s/auth/realms/master/protocol/openid-connect/auth" .Values.pxmonitor.pxCentralEndpoint }} 
     token_url = {{ printf "https://%s/auth/realms/master/protocol/openid-connect/token" .Values.pxmonitor.pxCentralEndpoint }} 

--- a/px-central/templates/px-monitor/grafana/grafana-config.yaml
+++ b/px-central/templates/px-monitor/grafana/grafana-config.yaml
@@ -17,8 +17,12 @@ data:
     auto_assign_org_role = Admin
 
     [server]
-    domain = {{ .Values.pxmonitor.pxCentralEndpoint }} 
-    root_url = "%(protocol)s://%(domain)s/grafana"
+    domain = {{ .Values.pxmonitor.pxCentralEndpoint }}
+    {{- if eq $sslEnabled true }}
+    root_url = {{ printf "https://%s/grafana" .Values.pxmonitor.pxCentralEndpoint}}
+    {{- else }}
+    root_url = {{ printf "http://%s/grafana" .Values.pxmonitor.pxCentralEndpoint}}
+    {{- end }}
     enforce_domain = false
 
     [auth.basic]
@@ -29,7 +33,7 @@ data:
     enabled= true
     client_id= {{ .Values.pxmonitor.oidcClientID }}
     name = "OIDC"
-    client_secret = {{ .Values.pxmonitor.oidcClientSecret }}
+    client_secret = 
     {{- if eq $sslEnabled true }}
     auth_url = {{ printf "https://%s/auth/realms/master/protocol/openid-connect/auth" .Values.pxmonitor.pxCentralEndpoint }} 
     token_url = {{ printf "https://%s/auth/realms/master/protocol/openid-connect/token" .Values.pxmonitor.pxCentralEndpoint }} 

--- a/px-central/values.yaml
+++ b/px-central/values.yaml
@@ -62,7 +62,6 @@ pxmonitor:
   pxCentralEndpoint: 
   sslEnabled: false
   oidcClientID: pxcentral
-  oidcClientSecret: ""
   nodeAffinityLabel:
 
 service:


### PR DESCRIPTION
Signed-off by: Diptiranjan

Removed the helm key for setting the oidc-client-secret during px-monitor install.