### PR TITLE
Removed the mongo-migration-status configmap as currently, it will be stored in a mongo document.

### DIFF
--- a/px-central/templates/px-backup/pxcentral-backup.yaml
+++ b/px-central/templates/px-backup/pxcentral-backup.yaml
@@ -39,18 +39,6 @@ metadata:
 data:
   enable: "{{ .Values.pxbackup.callHome }}"
 ---
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: mongo-migration-status
-  namespace: {{ .Release.Namespace }}
-  labels:
-    app: px-backup
-    app.kubernetes.io/component: px-backup
-{{- include "px-central.labels" . | nindent 4 }}
-data:
-  status: "{{ .Values.pxbackup.mongomigration}}"
----
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -177,6 +165,7 @@ spec:
         {{- else }}
         - --datastoreEndpoints=etcd:http://pxc-backup-etcd-0.pxc-backup-etcd-headless:2379,etcd:http://pxc-backup-etcd-1.pxc-backup-etcd-headless:2379,etcd:http://pxc-backup-etcd-2.pxc-backup-etcd-headless:2379
         {{- end }}
+        - --mongoMigration={{.Values.pxbackup.mongomigration}}
       {{- if .Values.caCertsSecretName }}
       volumes:
         - name: ssl-cert-dir

--- a/px-central/values.yaml
+++ b/px-central/values.yaml
@@ -44,7 +44,7 @@ pxbackup:
   callHome: true
   nodeAffinityLabel:
   datastore: etcd
-  mongomigration: incomplete
+  mongomigration: complete
 
 pxlicenseserver:
   enabled: false

--- a/single_chart_migration/migration.sh
+++ b/single_chart_migration/migration.sh
@@ -273,6 +273,8 @@ fi
 
 # TODO: for now adding it default. Need to add based on the version check.
 upgrade_cmd="$upgrade_cmd --set pxbackup.datastore=mongodb"
+# mongomigration will be set to incomplete by default, since this script will be called for upgrade only
+upgrade_cmd="$upgrade_cmd --set pxbackup.mongomigration=incomplete"
 
 echo "upgrade command: $upgrade_cmd"
 $upgrade_cmd


### PR DESCRIPTION
**What this PR does / why we need it**:
Removed the mongo-migration-status configmap as currently, it will be stored in a mongo document.

        - Changed the default value of mongomigration to complete
        - Also overwritten the default value of mongomigration to incomplete in migrations.sh,
          as it will do helm upgrade.


