### PR TITLE
Added --mongo-trail-migration option.

### DIFF
--- a/single_chart_migration/mongo.yaml
+++ b/single_chart_migration/mongo.yaml
@@ -1,0 +1,229 @@
+# Source: px-central/templates/px-backup/pxcentral-mongodb.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pxc-backup-mongodb-trial
+  labels:
+    app.kubernetes.io/component: pxc-backup-mongodb-trial
+    app.kubernetes.io/name: px-central
+    app.kubernetes.io/instance: "px-backup"
+secrets:
+  - name: pxc-backup-mongodb-trial
+---
+# Source: px-central/templates/px-backup/pxcentral-mongodb.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/component: pxc-backup-mongodb-trial
+    app.kubernetes.io/name: px-central
+    app.kubernetes.io/instance: "px-backup"
+  name: pxc-backup-mongodb-trial
+type: Opaque
+stringData:
+  mongodb-root-password: "pxcentral"
+  mongodb-password: "Password1"
+  mongodb-replica-set-key: "pxbackup"
+---
+# Source: px-central/templates/px-backup/pxcentral-mongodb.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pxc-backup-mongodb-trial-scripts
+  labels:
+    app.kubernetes.io/component: pxc-backup-mongodb-trial
+    app.kubernetes.io/name: px-central
+    app.kubernetes.io/instance: "px-backup"
+data:
+  setup.sh: |-
+    #!/bin/bash
+
+    echo "Advertised Hostname: $MONGODB_ADVERTISED_HOSTNAME"
+
+    if [[ "$MY_POD_NAME" = "pxc-backup-mongodb-trial-0" ]]; then
+        echo "Pod name matches initial primary pod name, configuring node as a primary"
+        export MONGODB_REPLICA_SET_MODE="primary"
+    else
+        echo "Pod name doesn't match initial primary pod name, configuring node as a secondary"
+        export MONGODB_REPLICA_SET_MODE="secondary"
+        export MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD="$MONGODB_ROOT_PASSWORD"
+        export MONGODB_INITIAL_PRIMARY_PORT_NUMBER="$MONGODB_PORT_NUMBER"
+        export MONGODB_ROOT_PASSWORD="" MONGODB_USERNAME="" MONGODB_DATABASE="" MONGODB_PASSWORD=""
+    fi
+
+    exec /opt/bitnami/scripts/mongodb/entrypoint.sh /opt/bitnami/scripts/mongodb/run.sh
+---
+# Source: px-central/templates/px-backup/pxcentral-mongodb.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: pxc-backup-mongodb-trial-headless
+  labels:
+    app.kubernetes.io/component: pxc-backup-mongodb-trial
+    app.kubernetes.io/name: px-central
+    app.kubernetes.io/instance: "px-backup"
+spec:
+  type: ClusterIP
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - name: mongodb
+      port: 27017
+      targetPort: mongodb
+  selector:
+    app.kubernetes.io/component: pxc-backup-mongodb-trial
+---
+# Source: px-central/templates/px-backup/pxcentral-mongodb.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: pxc-backup-mongodb-trial
+  labels:
+    app.kubernetes.io/component: pxc-backup-mongodb-trial
+    app.kubernetes.io/name: px-central
+    app.kubernetes.io/instance: "px-backup"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: px-backup
+      app.kubernetes.io/instance: px-backup
+      app.kubernetes.io/component: pxc-backup-mongodb-trial
+  serviceName: pxc-backup-mongodb-trial-headless
+  podManagementPolicy: OrderedReady
+  replicas: 3
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: px-backup
+        app.kubernetes.io/instance: px-backup
+        app.kubernetes.io/component: pxc-backup-mongodb-trial
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: pxbackup/enabled
+                operator: NotIn
+                values:
+                - "false"
+      imagePullSecrets:
+        - name: "docregistry-secret"
+      serviceAccountName: pxc-backup-mongodb-trial
+      securityContext:
+        fsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+      containers:
+        - name: mongodb
+          image: docker.io/bitnami/mongodb:4.4.4-debian-10-r30
+          imagePullPolicy: Always
+          command:
+            - /scripts/setup.sh
+          env:
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: K8S_SERVICE_NAME
+              value: pxc-backup-mongodb-trial-headless
+            - name: MONGODB_INITIAL_PRIMARY_HOST
+              value: pxc-backup-mongodb-trial-0.$(K8S_SERVICE_NAME)
+            - name: MONGODB_REPLICA_SET_NAME
+              value: rs0
+            - name: MONGODB_ADVERTISED_HOSTNAME
+              value: $(MY_POD_NAME).$(K8S_SERVICE_NAME)
+            - name: SHARED_FILE
+              value: "/shared/info.txt"
+            - name: MONGODB_USERNAME
+              value: pxbackup
+            - name: MONGODB_DATABASE
+              value: px-backup
+            - name: MONGODB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: mongodb-password
+                  name: pxc-backup-mongodb-trial
+            - name: MONGODB_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: mongodb-root-password
+                  name: pxc-backup-mongodb-trial
+            - name: MONGODB_REPLICA_SET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: mongodb-replica-set-key
+                  name: pxc-backup-mongodb-trial
+            - name: ALLOW_EMPTY_PASSWORD
+              value: "no"
+            - name: MONGODB_SYSTEM_LOG_VERBOSITY
+              value: "0"
+            - name: MONGODB_DISABLE_SYSTEM_LOG
+              value: "no"
+            - name: MONGODB_ENABLE_IPV6
+              value: "no"
+            - name: MONGODB_ENABLE_DIRECTORY_PER_DB
+              value: "no"
+          ports:
+            - containerPort: 27017
+              name: mongodb
+              protocol: TCP
+          livenessProbe:
+            exec:
+              command:
+              - mongo
+              - --disableImplicitSessions
+              - --eval
+              - db.adminCommand('ping')
+            failureThreshold: 6
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+              - bash
+              - -ec
+              - |
+                mongo --disableImplicitSessions $TLS_OPTIONS --eval 'db.hello().isWritablePrimary || db.hello().secondary' | grep -q 'true'
+            failureThreshold: 6
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          volumeMounts:
+            - mountPath: /bitnami/mongodb
+              name: pxc-mongodb-data
+            - mountPath: /scripts/setup.sh
+              name: scripts
+              subPath: setup.sh
+      volumes:
+        - name: scripts
+          configMap:
+            defaultMode: 493
+            name: pxc-backup-mongodb-trial-scripts
+  volumeClaimTemplates:
+    - metadata:
+        name: pxc-mongodb-data
+      spec:
+        accessModes:
+          - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: 64Gi
+        storageClassName: mysql-sc
+


### PR DESCRIPTION

**What this PR does / why we need it**:
    Added --mongo-trail-migration option.

        - As part of --mongo-trail-migration option, following steps will be executed.
        - Will deploy the temporary mongo deploy
        - Will being down the px-backup, to avoid updates to the etcd datastore.
        - Will execute migrationctl tool to migrate the objects from etcd to mongoDB.
        - As part of migrationctl, we will dump a report which will contain details
          about all the objects that are migrated.
        - Delete the temporary mongo deployment.
        
    Added migrationctl and mongo.yaml files

**Testing:**
```
[root@central-stump-ninja-3 single_chart_migration]# ./migration.sh --namespace px-backup --helmrepo /root/helm --mongo-trail-migration
release namespace = px-backup
helm repo name = /root/helm
mongotrailmigration set true
mongotrailmigration case
using storage class for mongo mysql-sc
serviceaccount/pxc-backup-mongodb-trail created
secret/pxc-backup-mongodb-trail created
configmap/pxc-backup-mongodb-trail-scripts created
service/pxc-backup-mongodb-trail-headless created
statefulset.apps/pxc-backup-mongodb-trail created
Waiting for mongoDB to be in running state
mongodb datastore is not ready yet
mongodb datastore is not ready yet
mongodb datastore is not ready yet
mongodb datastore is not ready yet
mongodb datastore is not ready yet
mongodb datastore is not ready yet
mongodb datastore is not ready yet
mongodb datastore is not ready yet
mongodb datastore is not ready yet
mongodb datastore is not ready yet
mongodb datastore is not ready yet
mongodb datastore is not ready yet
mongodb datastore is not ready yet
mongodb datastore is not ready yet
mongodb datastore is not ready yet
mongodb datastore is not ready yet
mongodb datastore is not ready yet
deployment.extensions/px-backup scaled
INFO[0000] created kv instance                           func=initKv package=datastore
INFO[0000] Setting lock timeout to: 3m0s

-----------------------------------------------------------------------
			MONGO MIGRATION STATUS REPORT
-----------------------------------------------------------------------
ObjectType		ETCDCount	MongoCount	TimeTaken
-----------------------------------------------------------------------
organizationObject	2		2		6.286088ms
Backup			3		3		17.853667ms
CloudCredential		10		10		23.180817ms
BackupSchedule		0		0		4.209105ms
BackupLocation		1		1		8.645708ms
Cluster			1		1		8.187959ms
License			1		1		5.649895ms
Restore			1		1		10.831525ms
Rule			0		0		4.129531ms
SchedulePolicy		1		1		6.070527ms
-----------------------------------------------------------------------
TOTAL TIME TAKEN FOR MIGRATION: 97.658925ms
-----------------------------------------------------------------------

statefulset.apps "pxc-backup-mongodb-trail" deleted
serviceaccount "pxc-backup-mongodb-trail" deleted
secret "pxc-backup-mongodb-trail" deleted
configmap "pxc-backup-mongodb-trail-scripts" deleted
service "pxc-backup-mongodb-trail-headless" deleted
persistentvolumeclaim "pxc-mongodb-data-pxc-backup-mongodb-trail-0" deleted
persistentvolumeclaim "pxc-mongodb-data-pxc-backup-mongodb-trail-1" deleted
persistentvolumeclaim "pxc-mongodb-data-pxc-backup-mongodb-trail-2" deleted
deployment.extensions/px-backup scaled
[root@central-stump-ninja-3 single_chart_migration]#
```
