### PR TITLE
[OC-748]: Retaining px-backup-ui for smooth upgrade experience.

### DIFF
--- a/px-central/README.md
+++ b/px-central/README.md
@@ -504,7 +504,7 @@ The following tables lists the configurable parameters of the PX-Backup chart an
 Parameter | Description | Default
 --- | --- | ---
 `persistentStorage` | Persistent storage for all px-central components | `""`
-`persistentStorage.enabled` | Enable persistent storage | `false`
+`persistentStorage.enabled` | Enable persistent storage | `true`
 `persistentStorage.storageClassName` | Provide storage class name which exists | `""`
 `persistentStorage.mysqlVolumeSize` | MySQL volume size | `"100Gi"`
 `persistentStorage.etcdVolumeSize` | ETCD volume size | `"64Gi"`

--- a/px-central/templates/px-lighthouse/px-central-ui/pxcentral-ui.yaml
+++ b/px-central/templates/px-lighthouse/px-central-ui/pxcentral-ui.yaml
@@ -576,3 +576,22 @@ spec:
       targetPort: 8080
       protocol: TCP
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: px-backup-ui
+  namespace: {{ .Release.Namespace }}
+  labels:
+    run: pxcentral-frontend
+    app.kubernetes.io/component: pxcentral-frontend
+{{- include "px-central.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.pxBackupUIServiceType }}
+  selector:
+    run: pxcentral-frontend
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+      protocol: TCP
+---

--- a/px-central/values.yaml
+++ b/px-central/values.yaml
@@ -70,6 +70,7 @@ pxmonitor:
 
 service:
   pxCentralUIServiceType: "LoadBalancer"
+  pxBackupUIServiceType: "LoadBalancer"
   grafanaServiceType: "NodePort"
   cortexNginxServiceType: "NodePort"
 

--- a/single_chart_migration/README.md
+++ b/single_chart_migration/README.md
@@ -42,3 +42,5 @@ $ helm ls -A | grep "px-backup-[0-9].[0-9].[0-9]" | awk '{print $2}'
 ```console
 $ ./migration.sh --namespace <namespace> --helmrepo <helm repo name>
 ```
+
+**px-backup-ui service has been kept for backward compatibility but will soon be deprecated. Please modify the ingress or routes which have been using px-backup-ui service to use px-central-ui service instead.**

--- a/single_chart_migration/migration.sh
+++ b/single_chart_migration/migration.sh
@@ -381,8 +381,9 @@ $helm_cmd list --namespace $namespace
 echo -e "
 #######################################################################################################
 ###                                                                                                 ###
-### From 1.3.0 version, 'px-backup-ui' service has been renamed to 'px-central-ui'.                 ###
-### Please modify all ingress or routes which have been configured using the service px-backup-ui.  ###
+### px-backup-ui service has been kept for backward compatibility but will soon be deprecated.      ###
+### Please modify the ingress or routes which have been using px-backup-ui service                  ###
+### to use px-central-ui service instead.                                                           ###
 ###                                                                                                 ###  
 #######################################################################################################
 "


### PR DESCRIPTION
 px-central-ui service will also be going to remain.

Signed-off By: Diptiranjan

Test:
1. Fresh Install 

kubectl get svc -n px-backup
NAME                                     TYPE           CLUSTER-IP      EXTERNAL-IP   PORT(S)               AGE
px-backup                                ClusterIP      10.233.48.4     <none>        10002/TCP,10001/TCP   33m
px-backup-ui                             LoadBalancer   10.233.24.153   <pending>     80:30917/TCP          33m
px-central-ui                            LoadBalancer   10.233.17.237   <pending>     80:30170/TCP          33m
pxc-backup-mongodb-headless              ClusterIP      None            <none>        27017/TCP             33m
pxcentral-apiserver                      ClusterIP      10.233.55.176   <none>        10005/TCP,10006/TCP   33m
pxcentral-backend                        ClusterIP      10.233.18.222   <none>        80/TCP                33m
pxcentral-cortex-nginx                   NodePort       10.233.30.254   <none>        80:30076/TCP          33m
pxcentral-frontend                       ClusterIP      10.233.28.245   <none>        80/TCP                33m
pxcentral-grafana                        NodePort       10.233.57.55    <none>        3000:31736/TCP        33m
pxcentral-keycloak-headless              ClusterIP      None            <none>        80/TCP,8443/TCP       33m
pxcentral-keycloak-http                  ClusterIP      10.233.49.24    <none>        80/TCP,8443/TCP       33m
pxcentral-keycloak-postgresql            ClusterIP      10.233.51.187   <none>        5432/TCP              33m
pxcentral-keycloak-postgresql-headless   ClusterIP      None            <none>        5432/TCP              33m
pxcentral-lh-middleware                  ClusterIP      10.233.18.201   <none>        8091/TCP,8092/TCP     33m
pxcentral-license                        ClusterIP      10.233.60.54    <none>        7070/TCP              33m
pxcentral-mysql                          ClusterIP      10.233.53.170   <none>        3306/TCP              33m

2. Upgrade

before upgrade:

 kubectl get svc -n px-backup
NAME                                     TYPE           CLUSTER-IP      EXTERNAL-IP   PORT(S)               AGE
px-backup                                ClusterIP      10.233.60.22    <none>        10002/TCP,10001/TCP   10m
px-backup-ui                             LoadBalancer   10.233.49.4     <pending>     80:30952/TCP          10m
pxc-backup-etcd                          ClusterIP      10.233.63.229   <none>        2379/TCP,2380/TCP     10m
pxc-backup-etcd-headless                 ClusterIP      None            <none>        2379/TCP,2380/TCP     10m
pxcentral-apiserver                      ClusterIP      10.233.44.148   <none>        10005/TCP,10006/TCP   10m
pxcentral-backend                        ClusterIP      10.233.7.51     <none>        80/TCP                10m
pxcentral-cortex-nginx                   NodePort       10.233.9.226    <none>        80:31252/TCP          10m
pxcentral-frontend                       ClusterIP      10.233.13.8     <none>        80/TCP                10m
pxcentral-grafana                        NodePort       10.233.51.101   <none>        3000:30364/TCP        10m
pxcentral-keycloak-headless              ClusterIP      None            <none>        80/TCP,8443/TCP       10m
pxcentral-keycloak-http                  ClusterIP      10.233.42.211   <none>        80/TCP,8443/TCP       10m
pxcentral-keycloak-postgresql            ClusterIP      10.233.31.206   <none>        5432/TCP              10m
pxcentral-keycloak-postgresql-headless   ClusterIP      None            <none>        5432/TCP              10m
pxcentral-lh-middleware                  ClusterIP      10.233.52.191   <none>        8091/TCP,8092/TCP     10m
pxcentral-mysql                          ClusterIP      10.233.3.45     <none>        3306/TCP              10m

After upgrade:

kubectl get svc -n px-backup
NAME                                     TYPE           CLUSTER-IP      EXTERNAL-IP   PORT(S)               AGE
px-backup                                ClusterIP      10.233.60.22    <none>        10002/TCP,10001/TCP   20m
px-backup-ui                             LoadBalancer   10.233.49.4     <pending>     80:30952/TCP          20m
px-central-ui                            LoadBalancer   10.233.58.84    <pending>     80:30791/TCP          9m21s
pxc-backup-etcd                          ClusterIP      10.233.63.229   <none>        2379/TCP,2380/TCP     20m
pxc-backup-etcd-headless                 ClusterIP      None            <none>        2379/TCP,2380/TCP     20m
pxc-backup-mongodb-headless              ClusterIP      None            <none>        27017/TCP             9m21s
pxcentral-apiserver                      ClusterIP      10.233.44.148   <none>        10005/TCP,10006/TCP   20m
pxcentral-backend                        ClusterIP      10.233.7.51     <none>        80/TCP                20m
pxcentral-cortex-nginx                   NodePort       10.233.9.226    <none>        80:31252/TCP          20m
pxcentral-frontend                       ClusterIP      10.233.13.8     <none>        80/TCP                20m
pxcentral-grafana                        NodePort       10.233.51.101   <none>        3000:30364/TCP        20m
pxcentral-keycloak-headless              ClusterIP      None            <none>        80/TCP,8443/TCP       20m
pxcentral-keycloak-http                  ClusterIP      10.233.42.211   <none>        80/TCP,8443/TCP       20m
pxcentral-keycloak-postgresql            ClusterIP      10.233.31.206   <none>        5432/TCP              20m
pxcentral-keycloak-postgresql-headless   ClusterIP      None            <none>        5432/TCP              20m
pxcentral-lh-middleware                  ClusterIP      10.233.52.191   <none>        8091/TCP,8092/TCP     20m
pxcentral-mysql                          ClusterIP      10.233.3.45     <none>        3306/TCP              20m

