### PR TITLE
post-install-job tag to be 2.0.0 for rolling back after failure with migration.

### DIFF
--- a/single_chart_migration/migration.sh
+++ b/single_chart_migration/migration.sh
@@ -51,7 +51,7 @@ cassandra_pvc_name="pxcentral-cassandra-data-pxcentral-cortex-cassandra-0"
 job_registry="docker.io"
 job_repo="portworx"
 job_image="pxcentral-onprem-post-setup"
-job_imagetag="2.0.0-dev"
+job_imagetag="2.0.0"
 job_pull_secret="docregistry-secret"
 
 mongo_registry="docker.io"


### PR DESCRIPTION
Signed-off-by: Diptiranjan