### PR TITLE
Delete extra labels for px-central

### DIFF
--- a/charts/px-central/templates/_helpers.tpl
+++ b/charts/px-central/templates/_helpers.tpl
@@ -34,7 +34,6 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "px-central.labels" -}}
-helm.sh/chart: {{ include "px-central.chart" . }}
 app.kubernetes.io/name: {{ template "px-central.name" . }}
 app.kubernetes.io/instance: {{.Release.Name | quote }}
 app.kubernetes.io/managed-by: {{.Release.Service | quote }}


### PR DESCRIPTION
Signed-off-by: Serhii Aheienko <serhii.aheienko@gmail.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Flux fails to install the px-central chart with the following error:
```
For the px-central chart helm generates a few similar `helm.sh/chart` labels and it causes flux to fail:
```

The reason that px-central deployment has a few values for the `helm.sh/chart` label and it causes flux to fail (it has a few extra checks on top of helm). Update the labels function for fix this issue.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

