### PR TITLE
[CHERRY-PICK] fixed OC-1046: wrong namespace shown, updated to release namespace

### DIFF
--- a/charts/px-central/templates/NOTES.txt
+++ b/charts/px-central/templates/NOTES.txt
@@ -37,7 +37,7 @@ Access PX-Central UI:
 --------------------------------------------------
 Using port forwarding:
 
-    kubectl port-forward service/px-backup-ui 8080:80 --namespace px-backup
+    kubectl port-forward service/px-backup-ui 8080:80 --namespace {{ .Release.Namespace }}
 
 To access PX-Central:  http://localhost:8080
 {{- if eq .Release.IsInstall true }}


### PR DESCRIPTION

**What this PR does / why we need it**:
This PR is a cherry-pick of `Namespace fix for helm install prompt`
Changes are in master, cherry-picking to `2.1.0`

**Which issue(s) this PR fixes** (optional)
Closes # https://portworx.atlassian.net/browse/OC-1046



