### PR TITLE
[OC-1152]: Need to delete the previous prometheus resource for its upgrading during migration.

### DIFF
--- a/single_chart_migration/migration.sh
+++ b/single_chart_migration/migration.sh
@@ -597,6 +597,7 @@ if [ "$pxmonitor_enabled" == true ]; then
     change_annotation "servicemonitor" "$servicemonitorListMonitor"
     delete_resource "statefulset" "$statefulsetListMonitorDelete"
     delete_resource "deployment" "$deploymentListMonitorDelete"
+    delete_resource "prometheus" "$prometheusMonitor"
 fi
 
 if [ "$pxls_enabled" == true ]; then


### PR DESCRIPTION
signed-off-by: Diptiranjan

**What this PR does / why we need it**:
Deleting prometheus resource linked with old px-monitor chart to get upgraded with px-central chart.

**Which issue(s) this PR fixes** (optional)
Closes # OC-1152

**Special notes for your reviewer**:
*Test*
Successfully upgraded from 1.2.3 to 2.1.2 and no more prometheus pod crash is seen.
Results have been updated in OC-1152.

