### PR TITLE
kopiaexecutor needs to be 1.2.0.

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -14,7 +14,7 @@ modules:
   pxBackup:
     pxBackup: "docker.io/portworx/px-backup-base:2.2.0-dev"
     mongodb: "docker.io/portworx/mongodb:4.4.4-debian-10-r30"
-    kopiaExecutor: "docker.io/portworx/kopiaexecutor:1.1.0"
+    kopiaExecutor: "docker.io/portworx/kopiaexecutor:1.2.0"
   pxMonitor:
     cortex: "docker.io/portworx/cortex:v1.1.0"
     cassandra: "docker.io/portworx/cassandra:3.11.6-debian-10-r153"


### PR DESCRIPTION
Signed-off-by: Diptiranjan