### PR TITLE
create template for StorageCluster spec

### DIFF
--- a/charts/portworx/crds/core_v1_storagecluster_crd.yaml
+++ b/charts/portworx/crds/core_v1_storagecluster_crd.yaml
@@ -1,0 +1,1418 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: storageclusters.core.libopenstorage.org
+spec:
+  group: core.libopenstorage.org
+  names:
+    kind: StorageCluster
+    listKind: StorageClusterList
+    plural: storageclusters
+    singular: storagecluster
+    shortNames:
+    - stc
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    additionalPrinterColumns:
+    - description: The unique ID of the storage cluster
+      jsonPath: .status.clusterUid
+      name: Cluster UUID
+      type: string
+    - description: The status of the storage cluster
+      jsonPath: .status.phase
+      name: Status
+      type: string
+    - description: The version of the storage cluster
+      jsonPath: .spec.version
+      name: Version
+      type: string
+    - description: The age of the storage cluster
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            description: The desired behavior of the storage cluster.
+            properties:
+              metadata:
+                type: object
+                description: Metadata contains metadata for different storage cluster components.
+                properties:
+                  annotations:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                    description: >-
+                      The annotations section of spec is a map of map to pass custom annotations to different
+                      storage cluster components. The key specifies component in format of "kind/component",
+                      e.g. "deployment/stork" to pass custom annotations to stork deployment. The value is a map of
+                      string that contains custom annotation key and value pairs.
+                  labels:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                    description: >-
+                      The labels section of spec is a map of map to pass custom labels to different storage cluster
+                      components. The key specifies component in format of "kind/component", e.g. "service/portworx-api"
+                      to pass custom labels to portworx-api service. The value is a map of string that contains custom
+                      label key and value pairs.
+              resources:
+                type: object
+                description: Specifies the compute resource requirements for the storage pod.
+                properties:
+                  requests:
+                    type: object
+                    description: Requested resources for the storage pod.
+                    properties:
+                      memory:
+                        type: string
+                        description: Requested memory for the storage pod.
+                      cpu:
+                        type: string
+                        description: Requested cpu for the storage pod.
+              image:
+                type: string
+                description: Docker image of the storage driver.
+              version:
+                type: string
+                description: Version of the storage driver. This field is read-only.
+              imagePullPolicy:
+                type: string
+                description: Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always.
+              imagePullSecret:
+                type: string
+                description: Image pull secret is a reference to secret in the same namespace as the
+                  StorageCluster. It is used for pulling all images used by the StorageCluster.
+              customImageRegistry:
+                type: string
+                description: >-
+                  Custom container image registry server that will be used instead of
+                  index.docker.io to download Docker images. This may include the repository as well.
+                  (Example: myregistry.net:5443 or myregistry.com/myrepository)
+              preserveFullCustomImageRegistry:
+                type: boolean
+                description: >-
+                  Setting this to true this stops part of the image tag being swallowed when setting a
+                  customImageRegistry with a / in it. When set to false using a customImageRegistry of
+                  `example.io/public` and an image of `portworx/oci-monitor` the full image path is is
+                  `example.io/public/oci-monitor`, setting to true gives you
+                  `example.io/public/portworx/oci-monitor`. Defaults to false
+              secretsProvider:
+                type: string
+                description: Secrets provider is the name of secret provider that driver will connect to.
+              startPort:
+                type: integer
+                format: int32
+                minimum: 0
+                description: Start port is the starting port in the range of ports used by the cluster.
+              autoUpdateComponents:
+                type: string
+                description: A strategy to determine how component versions are to be updated automatically.
+              updateStrategy:
+                type: object
+                description: An update strategy to replace existing StorageCluster pods with new pods.
+                properties:
+                  type:
+                    type: string
+                    description: Type of storage cluster update. Can be RollingUpdate or OnDelete.
+                      Default is RollingUpdate.
+                    enum:
+                    - RollingUpdate
+                    - OnDelete
+                  rollingUpdate:
+                    type: object
+                    description: Spec to control the desired behavior of storage cluster rolling update.
+                    properties:
+                      maxUnavailable:
+                        x-kubernetes-int-or-string: true
+                        description: >-
+                          The maximum number of StorageCluster pods that can be unavailable
+                          during the update. Value can be an absolute number (ex: 5) or a percentage of
+                          total number of StorageCluster pods at the start of the update (ex: 10%).
+                          Absolute number is calculated from percentage by rounding up. This cannot be 0.
+                          Default value is 1. Example: when this is set to 30%, at most 30% of the total
+                          number of nodes that should be running the storage pod can have their pods
+                          stopped for an update at any given time. The update starts by stopping at most
+                          30% of those StorageCluster pods and then brings up new StorageCluster pods in
+                          their place. Once the new pods are available, it then proceeds onto other
+                          StorageCluster pods, thus ensuring that at least 70% of original number of
+                          StorageCluster pods are available at all times during the update.
+              deleteStrategy:
+                type: object
+                description: Delete strategy to uninstall and wipe the storage cluster.
+                properties:
+                  type:
+                    type: string
+                    description: Type of storage cluster delete. Can be Uninstall or UninstallAndWipe.
+                      There is no default delete strategy. When no delete strategy only objects managed
+                      by the StorageCluster controller and owned by the StorageCluster object are deleted.
+                      The storage driver will be left in a state where it will not be managed by any object.
+                      Uninstall strategy ensures that the cluster is completely uninstalled even from the
+                      storage driver perspective. UninstallAndWipe strategy ensures that the cluster is
+                      completely uninstalled as well as the storage devices and metadata are wiped for
+                      reuse. This may result in data loss.
+                    enum:
+                    - Uninstall
+                    - UninstallAndWipe
+              revisionHistoryLimit:
+                type: integer
+                format: int32
+                description: The number of old history to retain to allow rollback. This is a pointer
+                  to distinguish between an explicit zero and not specified. Defaults to 10.
+              featureGates:
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+                description: This is a map of feature names to string values.
+              runtimeOptions:
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+                description: This is map of any runtime options that need to be sent to the storage
+                  driver. The value is a string.
+              placement:
+                type: object
+                description: Describes placement configuration for the storage cluster pods.
+                properties:
+                  nodeAffinity:
+                    type: object
+                    description: Describes node affinity scheduling rules for the storage cluster pods.
+                      This is exactly the same object as Kubernetes node affinity for pods.
+                    properties:
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        type: object
+                        properties:
+                          nodeSelectorTerms:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                    required:
+                                    - key
+                                    - operator
+                                matchFields:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                    required:
+                                    - key
+                                    - operator
+                        required:
+                        - nodeSelectorTerms
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            weight:
+                              type: integer
+                            preference:
+                              type: object
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                    required:
+                                    - key
+                                    - operator
+                                matchFields:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                    required:
+                                    - key
+                                    - operator
+                          required:
+                          - preference
+                          - weight
+                  tolerations:
+                    type: array
+                    description: Tolerations for all the pods deployed by the StorageCluster controller.
+                      The pod with this toleration attached will tolerate any taint that matches the
+                      triple <key,value,effect> using the matching operator <operator>.
+                    items:
+                      type: object
+                      properties:
+                        effect:
+                          type: string
+                          description: Effect indicates the taint effect to match. Empty means match
+                            all taint effects. When specified, allowed values are NoSchedule,
+                            PreferNoSchedule and NoExecute.
+                        key:
+                          type: string
+                          description: Key is the taint key that the toleration applies to. Empty means
+                            match all taint keys. If the key is empty, operator must be Exists; this
+                            combination means to match all values and all keys.
+                        operator:
+                          type: string
+                          description: "Operator represents a key's relationship to the value. Valid
+                            operators are Exists and Equal. Defaults to Equal. Exists is equivalent to
+                            wildcard for value, so that a pod can tolerate all taints of a particular category."
+                        value:
+                          type: string
+                          description: Value is the taint value the toleration matches to. If the operator
+                            is Exists, the value should be empty, otherwise just a regular string.
+                        tolerationSeconds:
+                          type: integer
+                          description: TolerationSeconds represents the period of time the toleration
+                            (which must be of effect NoExecute, otherwise this field is ignored) tolerates
+                            the taint. By default, it is not set, which means tolerate the taint forever
+                            (do not evict). Zero and negative values will be treated as 0 (evict
+                            immediately) by the system.
+              kvdb:
+                type: object
+                description: Details of KVDB that the storage driver will use.
+                properties:
+                  internal:
+                    type: boolean
+                    description: Flag indicating whether to use internal KVDB or an external KVDB.
+                  endpoints:
+                    type: array
+                    description: If using external KVDB, this is the list of KVDB endpoints.
+                    items:
+                      type: string
+                  authSecret:
+                    type: string
+                    description: Authentication secret is the name of Kubernetes secret containing
+                      information to authenticate with the external KVDB. It could have the username/password
+                      for basic auth, certificate information or an ACL token.
+              storage:
+                type: object
+                description: Details of the storage used by the storage driver.
+                properties:
+                  useAll:
+                    type: boolean
+                    description: Use all available, unformatted, unpartitioned devices. This will be
+                      ignored if spec.storage.devices is not empty.
+                  useAllWithPartitions:
+                    type: boolean
+                    description: Use all available unformatted devices. This will be
+                      ignored if spec.storage.devices is not empty.
+                  forceUseDisks:
+                    type: boolean
+                    description: Flag indicating to use the devices even if there is file system present
+                      on it. Note that the devices may be wiped before using.
+                  devices:
+                    type: array
+                    description: List of devices to be used by the storage driver.
+                    items:
+                      type: string
+                  cacheDevices:
+                    type: array
+                    description: List of cache devices to be used by the storage driver.
+                    items:
+                      type: string
+                  journalDevice:
+                    type: string
+                    description: Device used for journaling.
+                  systemMetadataDevice:
+                    type: string
+                    description: Device that will be used to store system metadata by the driver.
+                  kvdbDevice:
+                    type: string
+                    description: Device used for internal KVDB.
+              cloudStorage:
+                type: object
+                description: Details of storage used in cloud environment.
+                properties:
+                  provider:
+                    type: string
+                    description: Cloud provider name.
+                  maxStorageNodes:
+                    type: integer
+                    format: int32
+                    minimum: 0
+                    description: Maximum nodes that will have storage in the cluster.
+                  maxStorageNodesPerZone:
+                    type: integer
+                    format: int32
+                    minimum: 0
+                    description: Maximum nodes in every zone that will have storage in the cluster.
+                  maxStorageNodesPerZonePerNodeGroup:
+                    type: integer
+                    format: int32
+                    minimum: 0
+                    description: Maximum nodes in every zone in every node group that will have storage
+                      in the cluster.
+                  nodePoolLabel:
+                    type: string
+                    description: Kubernetes node label key with which nodes are grouped into node pools
+                      for storage distribution in cloud environment.
+                  deviceSpecs:
+                    type: array
+                    description: List of storage device specs. A cloud storage device will be created
+                      for every spec in the list. The specs will be applied to all nodes in the cluster
+                      up to spec.cloudStorage.maxStorageNodes or spec.cloudStorage.maxStorageNodesPerZone
+                      or spec.cloudStorage.maxStorageNodesPerZonePerNodeGroup.
+                      This will be ignored if spec.cloudStorage.capacitySpecs is present.
+                    items:
+                      type: string
+                  capacitySpecs:
+                    type: array
+                    description: List of cluster wide storage types and their capacities. A single
+                      capacity spec identifies a storage pool with a set of minimum requested IOPS
+                      and size. Based on the cloud provider, the total storage capacity will get
+                      divided amongst the nodes. The nodes bearing storage themselves will get
+                      uniformly distributed across all the zones.
+                    items:
+                      type: object
+                      properties:
+                        minIOPS:
+                          type: integer
+                          format: int64
+                          minimum: 0
+                          description: Minimum IOPS expected from the cloud drive.
+                        minCapacityInGiB:
+                          type: integer
+                          format: int64
+                          minimum: 0
+                          description: Minimum capacity for this storage cluster. The total capacity
+                            of devices created by this capacity spec should not be less than this
+                            number for the entire cluster.
+                        maxCapacityInGiB:
+                          type: integer
+                          format: int64
+                          minimum: 0
+                          description: Maximum capacity for this storage cluster. The total capacity
+                            of devices created by this capacity spec should not be greater than this
+                            number for the entire cluster.
+                        options:
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                          description: Additional options required to provision the drive in cloud.
+                  journalDeviceSpec:
+                    type: string
+                    description: Device spec for the journal device.
+                  systemMetadataDeviceSpec:
+                    type: string
+                    description: Device spec for the metadata device. This device will be used to store
+                      system metadata by the driver.
+                  kvdbDeviceSpec:
+                    type: string
+                    description: Device spec for internal KVDB device.
+              network:
+                type: object
+                description: Contains network information that is needed by the storage driver.
+                properties:
+                  dataInterface:
+                    type: string
+                    description: Name of the network interface used by the storage driver for data traffic.
+                  mgmtInterface:
+                    type: string
+                    description: Name of the network interface used by the storage driver for management traffic.
+              stork:
+                type: object
+                description: Contains STORK related spec.
+                properties:
+                  enabled:
+                    type: boolean
+                    description: Flag indicating whether STORK needs to be enabled.
+                  lockImage:
+                    type: boolean
+                    description: Flag indicating if the STORK image needs to be locked to the given image.
+                      If the image is not locked, it can be updated by the storage driver during upgrades.
+                  image:
+                    type: string
+                    description: Docker image of the STORK container.
+                  hostNetwork:
+                    type: boolean
+                    description: Flag indicating if Stork pods should run in host network.
+                  args:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                    description: >-
+                      It is map of arguments given to STORK. Example: driver: pxd
+                  env:
+                    type: array
+                    description: List of environment variables used by STORK. This is an array of
+                      Kubernetes EnvVar where the value can be given directly or from a source like field,
+                      config map or secret.
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        value:
+                          type: string
+                        valueFrom:
+                          type: object
+                          properties:
+                            configMapKeyRef:
+                              type: object
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                            fieldRef:
+                              type: object
+                              properties:
+                                apiVersion:
+                                  type: string
+                                fieldPath:
+                                  type: string
+                            resourceFieldRef:
+                              type: object
+                              properties:
+                                containerName:
+                                  type: string
+                                divisor:
+                                  type: string
+                                resource:
+                                  type: string
+                            secretKeyRef:
+                              type: object
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                  volumes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        readOnly:
+                          type: boolean
+                        mountPath:
+                          type: string
+                        mountPropagation:
+                          type: string
+                        hostPath:
+                          type: object
+                          properties:
+                            path:
+                              type: string
+                            type:
+                              type: string
+                        secret:
+                          type: object
+                          properties:
+                            secretName:
+                              type: string
+                            defaultMode:
+                              type: integer
+                            optional:
+                              type: boolean
+                            items:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  key:
+                                    type: string
+                                  path:
+                                    type: string
+                                  mode:
+                                    type: integer
+                        configMap:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            defaultMode:
+                              type: integer
+                            optional:
+                              type: boolean
+                            items:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  key:
+                                    type: string
+                                  path:
+                                    type: string
+                                  mode:
+                                    type: integer
+                        projected:
+                          type: object
+                          properties:
+                            defaultMode:
+                              type: integer
+                            sources:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  secret:
+                                    type: object
+                                    properties:
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                      items:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            path:
+                                              type: string
+                                            mode:
+                                              type: integer
+                                  configMap:
+                                    type: object
+                                    properties:
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                      items:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            path:
+                                              type: string
+                                            mode:
+                                              type: integer
+              userInterface:
+                type: object
+                description: Contains spec of a user interface for the storage driver.
+                properties:
+                  enabled:
+                    type: boolean
+                    description: Flag indicating whether the user interface needs to be enabled.
+                  lockImage:
+                    type: boolean
+                    description: Flag indicating if the user interface image needs to be locked to the given
+                      image. If the image is not locked, it can be updated by the storage driver during upgrades.
+                  image:
+                    type: string
+                    description: Docker image of the user interface container.
+                  env:
+                    type: array
+                    description: List of environment variables used by the UI components. This is an array
+                      of Kubernetes EnvVar where the value can be given directly or from a source like field,
+                      config map or secret.
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        value:
+                          type: string
+                        valueFrom:
+                          type: object
+                          properties:
+                            configMapKeyRef:
+                              type: object
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                            fieldRef:
+                              type: object
+                              properties:
+                                apiVersion:
+                                  type: string
+                                fieldPath:
+                                  type: string
+                            resourceFieldRef:
+                              type: object
+                              properties:
+                                containerName:
+                                  type: string
+                                divisor:
+                                  type: string
+                                resource:
+                                  type: string
+                            secretKeyRef:
+                              type: object
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+              autopilot:
+                type: object
+                description: Contains spec of autopilot component for storage driver.
+                properties:
+                  enabled:
+                    type: boolean
+                    description: Flag indicating whether autopilot needs to be enabled.
+                  lockImage:
+                    type: boolean
+                    description: Flag indicating if the autopilot image needs to be locked to the given image.
+                      If the image is not locked, it can be updated by the storage driver during upgrades.
+                  image:
+                    type: string
+                    description: Docker image of the autopilot container.
+                  args:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                    description: >-
+                      It is a map of arguments provided to autopilot. Example: log-level: debug
+                  env:
+                    type: array
+                    description: List of environment variables used by autopilot. This is an array of
+                      Kubernetes EnvVar where the value can be given directly or from a source like field,
+                      config map or secret.
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        value:
+                          type: string
+                        valueFrom:
+                          type: object
+                          properties:
+                            configMapKeyRef:
+                              type: object
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                            fieldRef:
+                              type: object
+                              properties:
+                                apiVersion:
+                                  type: string
+                                fieldPath:
+                                  type: string
+                            resourceFieldRef:
+                              type: object
+                              properties:
+                                containerName:
+                                  type: string
+                                divisor:
+                                  type: string
+                                resource:
+                                  type: string
+                            secretKeyRef:
+                              type: object
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                  volumes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        readOnly:
+                          type: boolean
+                        mountPath:
+                          type: string
+                        mountPropagation:
+                          type: string
+                        hostPath:
+                          type: object
+                          properties:
+                            path:
+                              type: string
+                            type:
+                              type: string
+                        secret:
+                          type: object
+                          properties:
+                            secretName:
+                              type: string
+                            defaultMode:
+                              type: integer
+                            optional:
+                              type: boolean
+                            items:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  key:
+                                    type: string
+                                  path:
+                                    type: string
+                                  mode:
+                                    type: integer
+                        configMap:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            defaultMode:
+                              type: integer
+                            optional:
+                              type: boolean
+                            items:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  key:
+                                    type: string
+                                  path:
+                                    type: string
+                                  mode:
+                                    type: integer
+                        projected:
+                          type: object
+                          properties:
+                            defaultMode:
+                              type: integer
+                            sources:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  secret:
+                                    type: object
+                                    properties:
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                      items:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            path:
+                                              type: string
+                                            mode:
+                                              type: integer
+                                  configMap:
+                                    type: object
+                                    properties:
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                      items:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            path:
+                                              type: string
+                                            mode:
+                                              type: integer
+                  providers:
+                    type: array
+                    description: List of input data providers to autopilot.
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                          description: Unique name of the data provider.
+                        type:
+                          type: string
+                          description: Type of the data provider. For instance - prometheus
+                        params:
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                          description: Map of key-value params for the provider.
+              monitoring:
+                type: object
+                description: Contains monitoring configuration for the storage cluster.
+                properties:
+                  enableMetrics:
+                    type: boolean
+                    description: "If this flag is enabled it will expose the storage cluster metrics to external
+                      monitoring solutions like Prometheus. DEPRECATED - use prometheus.exportMetrics instead"
+                  prometheus:
+                    type: object
+                    description: Contains configuration of Prometheus to monitor the storage cluster.
+                    properties:
+                      exportMetrics:
+                        type: boolean
+                        description: If this flag is enabled it will expose the storage cluster metrics to Prometheus.
+                      enabled:
+                        type: boolean
+                        description: Flag indicating whether Prometheus stack needs to be enabled and deployed
+                          by the Storage operator.
+                      remoteWriteEndpoint:
+                        type: string
+                        description: Specifies the remote write endpoint for Prometheus.
+                      alertManager:
+                        type: object
+                        description: Contains configuration of AlertManager for the storage cluster.
+                        properties:
+                          enabled:
+                            type: boolean
+                            description: Flag indicating whether AlertManager needs to be enabled and deployed
+                              by the Storage operator.
+                  telemetry:
+                    type: object
+                    description: Contains telemetry configuration for the storage cluster.
+                    properties:
+                      enabled:
+                        type: boolean
+                        description: Flag indicates if telemetry component needs to be enabled
+                      image:
+                        type: string
+                        description: Docker image of the telemetry container.
+              security:
+                type: object
+                description: Contains security configuration for the storage cluster.
+                properties:
+                  enabled:
+                    type: boolean
+                    description: Flag indicating whether security features need to be enabled for the storage cluster.
+                  auth:
+                    type: object
+                    description: Authorization configurations for a RBAC enabled storage cluster
+                    properties:
+                      guestAccess:
+                        type: string
+                        description: Defines the access mode of a guest user
+                      selfSigned:
+                        type: object
+                        description: Configuration for self signed authentication
+                        properties:
+                          issuer:
+                            type: string
+                            description: Token issuer for the tokens used to connect with storage cluster.
+                          tokenLifetime:
+                            type: string
+                            description: Lifetime of auto-generated RBAC tokens to access the storage cluster.
+                          sharedSecret:
+                            type: string
+                            description: Shared secret is the name of the Kubernetes secret containing the shared key
+                              used for signing RBAC tokens. The secret has to be present in the StorageCluster namespace.
+              csi:
+                type: object
+                description: Contains CSI configuration for the storage cluster.
+                properties:
+                  enabled:
+                    type: boolean
+                    description: Flag indicating whether CSI needs to be installed for the storage cluster.
+                  installSnapshotController:
+                    type: boolean
+                    description: Flag indicating whether CSI Snapshot Controller needs to be installed for the storage cluster.
+                  topology:
+                    type: object
+                    description: Contains CSI topology configurations.
+                    properties:
+                      enabled:
+                        type: boolean
+                        description: Flag indicating whether CSI topology feature gate is enabled.
+              env:
+                type: array
+                description: List of environment variables used by the driver. This is an array of Kubernetes
+                  EnvVar where the value can be given directly or from a source like field, config map or secret.
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      type: string
+                    valueFrom:
+                      type: object
+                      properties:
+                        configMapKeyRef:
+                          type: object
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                            optional:
+                              type: boolean
+                        fieldRef:
+                          type: object
+                          properties:
+                            apiVersion:
+                              type: string
+                            fieldPath:
+                              type: string
+                        resourceFieldRef:
+                          type: object
+                          properties:
+                            containerName:
+                              type: string
+                            divisor:
+                              type: string
+                            resource:
+                              type: string
+                        secretKeyRef:
+                          type: object
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                            optional:
+                              type: boolean
+              volumes:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    readOnly:
+                      type: boolean
+                    mountPath:
+                      type: string
+                    mountPropagation:
+                      type: string
+                    hostPath:
+                      type: object
+                      properties:
+                        path:
+                          type: string
+                        type:
+                          type: string
+                    secret:
+                      type: object
+                      properties:
+                        secretName:
+                          type: string
+                        defaultMode:
+                          type: integer
+                        optional:
+                          type: boolean
+                        items:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              key:
+                                type: string
+                              path:
+                                type: string
+                              mode:
+                                type: integer
+                    configMap:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        defaultMode:
+                          type: integer
+                        optional:
+                          type: boolean
+                        items:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              key:
+                                type: string
+                              path:
+                                type: string
+                              mode:
+                                type: integer
+                    projected:
+                      type: object
+                      properties:
+                        defaultMode:
+                          type: integer
+                        sources:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              secret:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                  items:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        path:
+                                          type: string
+                                        mode:
+                                          type: integer
+                              configMap:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                  items:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        path:
+                                          type: string
+                                        mode:
+                                          type: integer
+              nodes:
+                type: array
+                description: Node level configurations that will override the configuration at cluster level.
+                  These configurations can be for individual nodes or can be grouped to override configuration
+                  of multiple nodes based on label selectors.
+                items:
+                  type: object
+                  properties:
+                    selector:
+                      type: object
+                      description: Configuration in this node block is applied to nodes based on this selector.
+                        Use either nodeName of labelSelector, not both. If nodeName is used, labelSelector will
+                        be ignored.
+                      properties:
+                        nodeName:
+                          type: string
+                          description: Name of the Kubernetes node that is to be selected. If present then the
+                            labelSelector is ignored even if the node with the given name is absent and the
+                            labelSelector matches another node.
+                        labelSelector:
+                          type: object
+                          description: It is a label query over all the nodes. The result of matchLabels and
+                            matchExpressions is ANDed. An empty label selector matches all nodes. A null
+                            label selector matches no objects.
+                          properties:
+                            matchLabels:
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                              description: It is a map of key-value pairs. A single key-value in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            matchExpressions:
+                              type: array
+                              description: It is a list of label selector requirements. The requirements are ANDed.
+                              items:
+                                type: object
+                                properties:
+                                  key:
+                                    type: string
+                                    description: It is the label key that the selector applies to.
+                                  operator:
+                                    type: string
+                                    description: "It represents a key's relationship to a set of values. Valid operators
+                                      are In, NotIn, Exists and DoesNotExist."
+                                  values:
+                                    type: array
+                                    description: It is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty.
+                                    items:
+                                      type: string
+                    storage:
+                      type: object
+                      description: Details of the storage used by the storage driver.
+                      properties:
+                        useAll:
+                          type: boolean
+                          description: Use all available, unformatted, unpartitioned devices. This will be
+                            ignored if spec.storage.devices is not empty.
+                        useAllWithPartitions:
+                          type: boolean
+                          description: Use all available unformatted devices. This will be
+                            ignored if spec.storage.devices is not empty.
+                        forceUseDisks:
+                          type: boolean
+                          description: Flag indicating to use the devices even if there is file system present
+                            on it. Note that the devices may be wiped before using.
+                        devices:
+                          type: array
+                          description: List of devices to be used by the storage driver.
+                          items:
+                            type: string
+                        cacheDevices:
+                          type: array
+                          description: List of cache devices to be used by the storage driver.
+                          items:
+                            type: string
+                        journalDevice:
+                          type: string
+                          description: Device used for journaling.
+                        systemMetadataDevice:
+                          type: string
+                          description: Device that will be used to store system metadata by the driver.
+                        kvdbDevice:
+                          type: string
+                          description: Device used for internal KVDB.
+                    cloudStorage:
+                      type: object
+                      description: Details of storage used in cloud environment.
+                      properties:
+                        deviceSpecs:
+                          type: array
+                          description: List of storage device specs. A cloud storage device will be created
+                            for every spec in the list. The specs will be applied to all nodes in the cluster
+                            that match the node group selector. The number of nodes that will come up with
+                            storage are constrained by maxStorageNodes, maxStorageNodesPerZone and
+                            maxStorageNodesPerZonePerNodeGroup.
+                          items:
+                            type: string
+                        journalDeviceSpec:
+                          type: string
+                          description: Device spec for the journal device.
+                        systemMetadataDeviceSpec:
+                          type: string
+                          description: Device spec for the metadata device. This device will be used to store
+                            system metadata by the driver.
+                        kvdbDeviceSpec:
+                          type: string
+                          description: Device spec for internal KVDB device.
+                        maxStorageNodesPerZonePerNodeGroup:
+                          type: integer
+                          format: int32
+                          minimum: 0
+                          description: Maximum nodes in every zone in every node group that will have storage
+                            in the cluster.
+                    network:
+                      type: object
+                      description: Contains network information that is needed by the storage driver.
+                      properties:
+                        dataInterface:
+                          type: string
+                          description: Name of the network interface used by the storage driver for data traffic.
+                        mgmtInterface:
+                          type: string
+                          description: Name of the network interface used by the storage driver for
+                            management traffic.
+                    runtimeOptions:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                      description: This is map of any runtime options that need to be sent to the storage
+                        driver. The value is a string. If runtime options are present here at node level,
+                        they will override the ones from cluster configuration.
+                    env:
+                      type: array
+                      description: List of environment variables used by the driver. This is an array
+                        of Kubernetes EnvVar where the value can be given directly or from a source
+                        like field, config map or secret. Environment variables specified here at the
+                        node level will be merged with the ones present in cluster configuration and
+                        sent to the nodes. If there is duplicate, the node level value will take precedence.
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                          valueFrom:
+                            type: object
+                            properties:
+                              configMapKeyRef:
+                                type: object
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                              fieldRef:
+                                type: object
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  fieldPath:
+                                    type: string
+                              resourceFieldRef:
+                                type: object
+                                properties:
+                                  containerName:
+                                    type: string
+                                  divisor:
+                                    type: string
+                                  resource:
+                                    type: string
+                              secretKeyRef:
+                                type: object
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+          status:
+            type: object
+            description: Most recently observed status of the storage cluster. This data may not be up to date.
+            properties:
+              clusterName:
+                type: string
+                description: Name of the storage cluster.
+              version:
+                type: string
+                description: Version of the storage driver.
+              clusterUid:
+                type: string
+                description: Unique ID of the storage cluster.
+              phase:
+                type: string
+                description: Phase of the StorageCluster is a simple, high-level summary of where the
+                  StorageCluster is in its lifecycle. The condition array contains more detailed
+                  information about the state of the cluster.
+              collisionCount:
+                type: integer
+                format: int32
+                description: Count of hash collisions for the StorageCluster. The StorageCluster controller
+                  uses this field as a collision avoidance mechanism when it needs to create the name of
+                  the newest ControllerRevision.
+              storage:
+                type: object
+                description: Contains details of storage in the cluster.
+                properties:
+                  storageNodesPerZone:
+                    type: integer
+                    format: int64
+                    description: The number of storage nodes per zone in the cluster.
+              desiredImages:
+                type: object
+                description: Represents all the desired images of various components.
+                properties:
+                  stork:
+                    type: string
+                    description: Desired image for stork.
+                  userInterface:
+                    type: string
+                    description: Desired image for user interface.
+                  autopilot:
+                    type: string
+                    description: Desired image for autopilot.
+                  csiNodeDriverRegistrar:
+                    type: string
+                    description: Desired image for CSI node driver registrar.
+                  csiDriverRegistrar:
+                    type: string
+                    description: Desired image for CSI driver registrar.
+                  csiProvisioner:
+                    type: string
+                    description: Desired image for CSI provisioner.
+                  csiAttacher:
+                    type: string
+                    description: Desired image for CSI attacher.
+                  csiResizer:
+                    type: string
+                    description: Desired image for CSI resizer.
+                  csiSnapshotter:
+                    type: string
+                    description: Desired image for CSI snapshotter.
+                  csiSnapshotController:
+                    type: string
+                    description: Desired image for CSI snapshot controller.
+                  csiHealthMonitorController:
+                    type: string
+                    description: Desired image for CSI health monitor controller.
+                  prometheusOperator:
+                    type: string
+                    description: Desired image for Prometheus operator.
+                  prometheusConfigMapReload:
+                    type: string
+                    description: Desired image for Prometheus config map reload.
+                  prometheusConfigReloader:
+                    type: string
+                    description: Desired image for Prometheus config reloader.
+                  prometheus:
+                    type: string
+                    description: Desired image for Prometheus.
+                  alertManager:
+                    type: string
+                    description: Desired image for AlertManager.
+                  telemetry:
+                    type: string
+                    description: Desired image for telemetry.
+                  metricsCollector:
+                    type: string
+                    description: Desired image for metrics collector.
+                  metricsCollectorProxy:
+                    type: string
+                    description: Desired image for metrics collector proxy.
+              conditions:
+                type: array
+                description: Contains details for the current condition of this cluster.
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                      description: Type of the condition.
+                    status:
+                      type: string
+                      description: Status of the condition.
+                    reason:
+                      type: string
+                      description: Reason is human readable message indicating details about the current
+                        state of the cluster.
+  - name: v1alpha1
+    served: false
+    storage: false
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true

--- a/charts/portworx/crds/core_v1_storagenode_crd.yaml
+++ b/charts/portworx/crds/core_v1_storagenode_crd.yaml
@@ -1,0 +1,157 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: storagenodes.core.libopenstorage.org
+spec:
+  group: core.libopenstorage.org
+  names:
+    kind: StorageNode
+    listKind: StorageNodeList
+    plural: storagenodes
+    singular: storagenode
+    shortNames:
+    - sn
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    additionalPrinterColumns:
+    - name: ID
+      type: string
+      description: The corresponding Kubernetes node name for the storage node
+      jsonPath: .status.nodeUid
+    - name: Status
+      type: string
+      description: The status of the storage node
+      jsonPath: .status.phase
+    - name: Version
+      type: string
+      description: The version of the storage node
+      jsonPath: .spec.version
+    - name: Age
+      type: date
+      description: The age of the storage cluster
+      jsonPath: .metadata.creationTimestamp
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            description: The desired behavior of the storage node. Currently changing the spec does
+              not affect the actual storage node in the cluster. Eventually spec in StorageNode will
+              override the spec from StorageCluster so that configuration can be overridden at node
+              level.
+            properties:
+              version:
+                type: string
+                description: Version of the storage driver on the node.
+              cloudStorage:
+                type: object
+                description: Details of storage on the node for cloud environments.
+                properties:
+                  driveConfigs:
+                    type: array
+                    description: List of cloud drive configs for the storage node.
+                    items:
+                      type: object
+                      properties:
+                        type:
+                          type: string
+                          description: Type of cloud drive.
+                        sizeInGiB:
+                          type: integer
+                          format: int64
+                          minimum: 0
+                          description: Size of cloud drive in GiB.
+                        iops:
+                          type: integer
+                          format: int64
+                          minimum: 0
+                          description: IOPS required from the cloud drive.
+                        options:
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                          description: Additional options for the cloud drive.
+          status:
+            type: object
+            description: Most recently observed status of the storage node. The data may not be up
+              to date.
+            properties:
+              nodeUid:
+                type: string
+                description: Unique ID of the storage node.
+              phase:
+                type: string
+                description: Phase of the StorageNode is a simple, high-level summary of where
+                  the StorageNode is in its lifecycle. The condition array contains more detailed
+                  information about the state of the node.
+              network:
+                type: object
+                description: Contains network information used by the storage node
+                properties:
+                  dataIP:
+                    type: string
+                    description: IP address used by the storage driver for data traffic.
+                  mgmtIP:
+                    type: string
+                    description: IP address used by the storage driver for management traffic.
+              storage:
+                type: object
+                description: Contains details of the status of storage for the node
+                properties:
+                  totalSize:
+                    type: string
+                    description: Cumulative total size of all storage pools on the node.
+                  usedSize:
+                    type: string
+                    description: Cumulative used size of all storage pools on the node.
+              conditions:
+                type: array
+                description: Contains details for the current condition of this storage node.
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                      description: Type of the condition.
+                    status:
+                      type: string
+                      description: Status of the condition.
+                    reason:
+                      type: string
+                      description: Reason is a unique one-word reason about the current state
+                        of the cluster.
+                    message:
+                      type: string
+                      description: Message is the human readable message indicating details about the
+                        current state of the cluster.
+                    lastTransitionTime:
+                      type: string
+                      format: date-time
+                      description: Time at which the condition changed.
+              geography:
+                type: object
+                description: Contains topology information for the storage node.
+                properties:
+                  region:
+                    type: string
+                    description: Region in which the storage node is placed.
+                  zone:
+                    type: string
+                    description: Zone in which the storage node is placed.
+                  rack:
+                    type: string
+                    description: Rack on which the storage node is placed.
+  - name: v1alpha1
+    served: false
+    storage: false
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true

--- a/charts/portworx/templates/hooks/pre-upgrade/retain-daemonset-install.yaml
+++ b/charts/portworx/templates/hooks/pre-upgrade/retain-daemonset-install.yaml
@@ -39,19 +39,66 @@ spec:
           {{- end}}
           command: ['/bin/sh',
                     '-c',
-                    'kubectl -n kube-system annotate daemonset portworx helm.sh/resource-policy=keep --overwrite;
-                     kubectl -n kube-system annotate daemonset portworx-api helm.sh/resource-policy=keep --overwrite;
-                     kubectl -n kube-system annotate namespace portworx helm.sh/resource-policy=keep --overwrite || true;
-                     kubectl -n kube-system annotate serviceaccount px-account helm.sh/resource-policy=keep --overwrite || true;
-                     kubectl -n kube-system annotate storageclass portworx-db-sc helm.sh/resource-policy=keep --overwrite || true;
-                     kubectl -n kube-system annotate storageclass portworx-db2-sc helm.sh/resource-policy=keep --overwrite || true;
-                     kubectl -n kube-system annotate storageclass portworx-shared-sc helm.sh/resource-policy=keep --overwrite || true;
-                     kubectl -n kube-system annotate storageclass portworx-null-sc helm.sh/resource-policy=keep --overwrite || true;
-                     kubectl annotate ClusterRole node-get-put-list-role helm.sh/resource-policy=keep --overwrite || true;
-                     kubectl annotate ClusterRoleBinding node-role-binding helm.sh/resource-policy=keep --overwrite || true;
-                     kubectl -n kube-system annotate role px-role helm.sh/resource-policy=keep --overwrite || true;
-                     kubectl -n kube-system annotate RoleBinding px-role-binding helm.sh/resource-policy=keep --overwrite || true;
+                    'kubectl -n kube-system annotate DaemonSet portworx-api helm.sh/resource-policy=keep --overwrite
+                     kubectl -n kube-system annotate DaemonSet portworx helm.sh/resource-policy=keep --overwrite
+
+                     kubectl -n kube-system annotate Service stork-service helm.sh/resource-policy=keep --overwrite || true;
+                     kubectl -n kube-system annotate Service prometheus helm.sh/resource-policy=keep --overwrite || true;
                      kubectl -n kube-system annotate Service portworx-service helm.sh/resource-policy=keep --overwrite || true;
+                     kubectl -n kube-system annotate Service autopilot helm.sh/resource-policy=keep --overwrite || true;
+                     kubectl -n kube-system annotate Service grafana helm.sh/resource-policy=keep --overwrite || true;
+                     kubectl -n kube-system annotate Service alertmanager-portworx helm.sh/resource-policy=keep --overwrite || true;
+                     kubectl -n kube-system annotate Service px-csi-service helm.sh/resource-policy=keep --overwrite || true;
                      kubectl -n kube-system annotate Service portworx-api helm.sh/resource-policy=keep --overwrite || true;
+                     kubectl -n kube-system annotate Deployment stork-scheduler helm.sh/resource-policy=keep --overwrite || true;
+                     kubectl -n kube-system annotate Deployment px-csi-ext helm.sh/resource-policy=keep --overwrite || true;
+                     kubectl -n kube-system annotate Deployment autopilot helm.sh/resource-policy=keep --overwrite || true;
+                     kubectl -n kube-system annotate Deployment grafana helm.sh/resource-policy=keep --overwrite || true;
+                     kubectl -n kube-system annotate Deployment stork helm.sh/resource-policy=keep --overwrite || true;
+                     kubectl -n kube-system annotate Deployment prometheus-operator helm.sh/resource-policy=keep --overwrite || true;
+
+                     kubectl -n kube-system annotate RoleBinding px-role-binding helm.sh/resource-policy=keep --overwrite || true;
+                     kubectl -n kube-system annotate Role px-role helm.sh/resource-policy=keep --overwrite || true;
+                     kubectl -n kube-system annotate ClusterRoleBinding stork-scheduler-role-binding helm.sh/resource-policy=keep --overwrite || true;
+                     kubectl -n kube-system annotate ClusterRoleBinding stork-role-binding helm.sh/resource-policy=keep --overwrite || true;
+                     kubectl -n kube-system annotate ClusterRoleBinding node-role-binding helm.sh/resource-policy=keep --overwrite || true;
+                     kubectl -n kube-system annotate ClusterRoleBinding prometheus helm.sh/resource-policy=keep --overwrite || true;
+                     kubectl -n kube-system annotate ClusterRoleBinding px-csi-role-binding helm.sh/resource-policy=keep --overwrite || true;
+                     kubectl -n kube-system annotate ClusterRoleBinding autopilot-role-binding helm.sh/resource-policy=keep --overwrite || true;
+                     kubectl -n kube-system annotate ClusterRoleBinding prometheus-operator helm.sh/resource-policy=keep --overwrite || true;
+
+                     kubectl -n kube-system annotate ClusterRole stork-scheduler-role helm.sh/resource-policy=keep --overwrite || true;
+                     kubectl -n kube-system annotate ClusterRole autopilot-role helm.sh/resource-policy=keep --overwrite || true;
+                     kubectl -n kube-system annotate ClusterRole prometheus helm.sh/resource-policy=keep --overwrite || true;
+                     kubectl -n kube-system annotate ClusterRole prometheus-operator helm.sh/resource-policy=keep --overwrite || true;
+                     kubectl -n kube-system annotate ClusterRole node-get-put-list-role helm.sh/resource-policy=keep --overwrite || true;
+                     kubectl -n kube-system annotate ClusterRole px-csi-role helm.sh/resource-policy=keep --overwrite || true;
+                     kubectl -n kube-system annotate ClusterRole stork-role helm.sh/resource-policy=keep --overwrite || true;
+
+                     kubectl -n kube-system annotate StorageClass stork-snapshot-sc helm.sh/resource-policy=keep --overwrite || true;
+                     kubectl -n kube-system annotate StorageClass portworx-shared-sc helm.sh/resource-policy=keep --overwrite || true;
+                     kubectl -n kube-system annotate StorageClass portworx-db2-sc helm.sh/resource-policy=keep --overwrite || true;
+                     kubectl -n kube-system annotate StorageClass portworx-null-sc helm.sh/resource-policy=keep --overwrite || true;
+                     kubectl -n kube-system annotate StorageClass portworx-db-sc helm.sh/resource-policy=keep --overwrite || true;
+
+                     kubectl -n kube-system annotate ConfigMap grafana-dashboard-config helm.sh/resource-policy=keep --overwrite || true;
+                     kubectl -n kube-system annotate ConfigMap autopilot-config helm.sh/resource-policy=keep --overwrite || true;
+                     kubectl -n kube-system annotate ConfigMap grafana-dashboards helm.sh/resource-policy=keep --overwrite || true;
+                     kubectl -n kube-system annotate ConfigMap grafana-source-config helm.sh/resource-policy=keep --overwrite || true;
+                     kubectl -n kube-system annotate ConfigMap stork-config helm.sh/resource-policy=keep --overwrite || true;
+
+                     kubectl -n kube-system annotate ServiceAccount stork-scheduler-account helm.sh/resource-policy=keep --overwrite || true;
+                     kubectl -n kube-system annotate ServiceAccount px-account helm.sh/resource-policy=keep --overwrite || true;
+                     kubectl -n kube-system annotate ServiceAccount prometheus-operator helm.sh/resource-policy=keep --overwrite || true;
+                     kubectl -n kube-system annotate ServiceAccount px-csi-account helm.sh/resource-policy=keep --overwrite || true;
+                     kubectl -n kube-system annotate ServiceAccount stork-account helm.sh/resource-policy=keep --overwrite || true;
+                     kubectl -n kube-system annotate ServiceAccount prometheus helm.sh/resource-policy=keep --overwrite || true;
+                     kubectl -n kube-system annotate ServiceAccount autopilot-account helm.sh/resource-policy=keep --overwrite || true;
+
+                     kubectl -n kube-system annotate Alertmanager portworx helm.sh/resource-policy=keep --overwrite || true;
+                     kubectl -n kube-system annotate CSIDriver pxd.portworx.com helm.sh/resource-policy=keep --overwrite || true;
+                     kubectl -n kube-system annotate Prometheus prometheus helm.sh/resource-policy=keep --overwrite || true;
+                     kubectl -n kube-system annotate PrometheusRule prometheus-portworx-rules-portworx.rules.yaml helm.sh/resource-policy=keep --overwrite || true;
+                     kubectl -n kube-system annotate ServiceMonitor portworx-prometheus-sm helm.sh/resource-policy=keep --overwrite || true;
                      ']
 

--- a/charts/portworx/templates/storage-cluster.yaml
+++ b/charts/portworx/templates/storage-cluster.yaml
@@ -1,0 +1,163 @@
+{{- if not (lookup "apps/v1" "DaemonSet" "kube-system" "portworx") }}
+
+  {{- $isCoreOS := .Values.isTargetOSCoreOS | default false }}
+  {{- $internalKVDB := .Values.internalKVDB | default false }}
+  {{- $etcdEndPoints := .Values.etcdEndPoint }}
+  {{- $openshiftInstall := .Values.openshiftInstall | default false }}
+  {{- $EKSInstall := .Values.EKSInstall | default false }}
+  {{- $pksInstall := .Values.pksInstall | default false }}
+  {{- $AKSInstall := .Values.AKSInstall | default false }}
+  {{- $usefileSystemDrive := .Values.usefileSystemDrive | default false }}
+  {{- $usedrivesAndPartitions := .Values.usedrivesAndPartitions | default false }}
+  {{- $secretType := .Values.secretType | default "k8s" }}
+  {{- $deployEnvironmentIKS := .Capabilities.KubeVersion.GitVersion | regexMatch "IKS" }}
+  {{- $drives := .Values.drives | default "none" }}
+  {{- $dataInterface := .Values.dataInterface | default "none" }}
+  {{- $managementInterface := .Values.managementInterface | default "none" }}
+  {{- $envVars := .Values.envVars | default "none" }}
+  {{- $customRegistryURL := .Values.customRegistryURL | default "none" }}
+  {{- $registrySecret := .Values.registrySecret | default "none" }}
+  {{- $licenseSecret := .Values.licenseSecret | default "none" }}
+  {{- $kvdbDevice := .Values.kvdbDevice | default "none" }}
+
+kind: StorageCluster
+apiVersion: core.libopenstorage.org/v1
+metadata:
+  name: "{{ required "Clustername cannot be empty" .Values.clusterName }}"
+  namespace: kube-system
+  annotations:
+    {{- if eq $openshiftInstall true }}
+    portworx.io/is-openshift: "true"
+    {{- end }}
+    {{- if eq $pksInstall true }}
+    portworx.io/is-pks: "true"
+    {{- end }}
+    {{- if eq $EKSInstall true }}
+    portworx.io/is-eks: "true"
+    {{- end }}
+    {{- if eq $AKSInstall true }}
+    portworx.io/is-aks: "true"
+    {{- end }}
+    # TODO: remove
+    portworx.io/migration-approved: "false"
+spec:
+  image: portworx/oci-monitor:{{ required "A valid Image tag is required in the SemVer format" .Values.imageVersion }}
+  imagePullPolicy: Always
+  {{- if not (eq $customRegistryURL "none") }}
+  customImageRegistry: {{ $customRegistryURL }}
+  {{- end }}
+  {{- if not (eq $registrySecret "none") }}
+  imagePullSecret: {{ $registrySecret }}
+  {{- end }}
+
+  kvdb:
+  {{- if eq $internalKVDB true }}
+    internal: true
+  {{- else }}
+    internal: false
+    {{- if empty $etcdEndPoints }}
+    "{{ required "A valid ETCD url in the format etcd:http://<your-etcd-endpoint> is required. Verify that the key is correct and there isnt any typo in specifying that, also ensure it is accessible from all node of your kubernetes cluster" .etcdEndPoint}}"
+    {{- else }}
+    endpoints:
+      {{- $endpoints := $etcdEndPoints | split ";" }}
+      {{- range $key, $val := $endpoints }}
+      - {{$val}}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+
+  storage:
+    {{- if not (eq $drives "none") }}
+    devices:
+      {{- $driveNames := $drives | split ";" }}
+      {{- range $index, $name := $driveNames }}
+      - {{ $name }}
+      {{- end }}
+    {{- end }}
+    {{- if eq $usefileSystemDrive true }}
+    forceUseDisks: true
+    {{- end }}
+    {{- if eq $usedrivesAndPartitions true }}
+    useAllWithPartitions: true
+    {{- end }}
+    {{- if ne $kvdbDevice "none" }}
+    kvdbDevice: {{ $kvdbDevice }}
+    {{- end }}
+
+  network:
+    {{- if ne $dataInterface "none" }}
+    dataInterface: {{ $dataInterface }}
+    {{- end -}}
+    {{- if ne $managementInterface "none" }}
+    mgmtInterface: {{ $managementInterface }}
+    {{- end -}}
+
+  {{- if ne $secretType "none" }}
+  secretsProvider: {{$secretType}}
+  {{- else }}
+    {{- if $deployEnvironmentIKS }}
+  secretsProvider: ibm-kp
+    {{- end }}
+  {{- end }}
+
+  env:
+  {{ if not (eq $envVars "none") }}
+    {{- $vars := $envVars | split ";" }}
+    {{- range $key, $val := $vars }}
+    {{-  $envVariable := $val | split "=" }}
+    - name: {{ $envVariable._0 | trim | quote }}
+      value: {{ $envVariable._1 | trim | quote }}
+    {{ end }}
+  {{- end }}
+  {{- if ne $licenseSecret "none" }}
+    - name: SAAS_ACCOUNT_KEY_STRING
+      valueFrom:
+        secretKeyRef:
+          name: "{{ $licenseSecret }}"
+          key: accountKey
+  {{- end }}
+
+  stork:
+    {{- if (and (.Values.stork) (eq .Values.stork true))}}
+    enabled: true
+      {{- if .Values.storkVersion }}
+    image: {{ template "px.getStorkImage" . }}:{{ required "A valid Image tag is required in the SemVer format" .Values.storkVersion }}
+      {{- end }}
+    {{- else }}
+    enabled: false
+    {{- end }}
+
+  {{- if eq $isCoreOS true}}
+  volumes:
+    - name: src
+      mountPath: /lib/modules
+      hostPath: /lib/modules
+  {{- end }}
+
+  {{- if (and (.Values.monitoring) (eq .Values.monitoring true)) }}
+  monitoring:
+    prometheus:
+      enabled: true
+      exportMetrics: true
+      alertManager:
+        enabled: true
+  {{- end }}
+
+  {{- if (and (.Values.csi) (eq .Values.csi true))}}
+  csi:
+    enabled: true
+  {{- end }}
+  {{- if (and (.Values.aut) (eq .Values.aut true))}}
+  autopilot:
+    enabled: true
+  {{- end }}
+
+  placement:
+    {{- with .Values.tolerations }}
+    tolerations:
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+
+{{- end }}
+
+

--- a/charts/portworx/values.yaml
+++ b/charts/portworx/values.yaml
@@ -64,6 +64,4 @@ clusterToken:
   secretName: px-vol-encryption    # Name of kubernetes secret to be created. Requires clusterToken.create to be true.
   serviceAccountName: px-create-cluster-token # Service account name to use for post-install hook to create cluster token
 
-replicas: 3                         # Replica count for pvc-controller, stork, stork-scheduler.
-
 #requirePxEnabledTag: true               # if set to true, portworx will only install on nodes with px/enabled: true label. Not required in most scenarios.


### PR DESCRIPTION
Create template to generate StorageCluster based on helm parameters.
- StorageCluster is only created by helm for fresh install
- If daemonset presents, then helm will not create StorageCluster, operator will create it afterwards
- External kvdb and cluster token are not supported yet, tracked by these two tickets:
[OPERATOR-727](https://portworx.atlassian.net/browse/OPERATOR-727) 
[OPERATOR-728](https://portworx.atlassian.net/browse/OPERATOR-728)
- There are some unsupported scenarios for operator generated StorageCluster: such as cloud provider detection and secret provider. we may want to let helm create storageCluster for migration
[OPERATOR-730](https://portworx.atlassian.net/browse/OPERATOR-730)