### PR TITLE
Portworx chart changes to support operator

### DIFF
--- a/charts/portworx/templates/hooks/pre-delete/delete-storagecluster.yaml
+++ b/charts/portworx/templates/hooks/pre-delete/delete-storagecluster.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.deployCluster }}
+{{- $customRegistryURL := .Values.customRegistryURL | default "none" }}
+{{- $registrySecret := .Values.registrySecret | default "none" }}
+{{- $clusterName := .Values.clusterName }}
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  namespace: kube-system
+  name: px-hook-delete-storagecluster
+  labels:
+    heritage: {{.Release.Service | quote }}
+    release: {{.Release.Name | quote }}
+    chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+    app.kubernetes.io/managed-by: {{.Release.Service | quote }}
+    app.kubernetes.io/instance: {{.Release.Name | quote }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 0
+  template:
+    spec:
+      {{- if not (eq $registrySecret "none") }}
+      imagePullSecrets:
+        - name: {{ $registrySecret }}
+      {{- end }}
+      serviceAccountName: {{ template "px.hookServiceAccount" . }}
+      restartPolicy: Never
+      containers:
+        - name: delete-storagecluster
+          {{- if eq $customRegistryURL "none" }}
+          image: "bitnami/kubectl:{{ template "px.kubectlImageTag" . }}"
+          {{- else}}
+          image: "{{ $customRegistryURL }}/bitnami/kubectl:{{ template "px.kubectlImageTag" . }}"
+          {{- end}}
+          command: ['/bin/sh',
+                    '-c',
+                    'kubectl -n kube-system delete storagecluster {{ $clusterName }}']
+{{- end }}

--- a/charts/portworx/templates/hooks/pre-upgrade/retain-daemonset-install.yaml
+++ b/charts/portworx/templates/hooks/pre-upgrade/retain-daemonset-install.yaml
@@ -1,3 +1,5 @@
+{{- if (lookup "apps/v1" "Daemonset" "kube-system" "portworx") }}
+
 {{- $customRegistryURL := .Values.customRegistryURL | default "none" }}
 {{- $registrySecret := .Values.registrySecret | default "none" }}
 
@@ -15,7 +17,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "10"
-    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   {{ if semverCompare ">= 1.8" .Capabilities.KubeVersion.GitVersion }}
   backoffLimit: 0
@@ -101,4 +103,4 @@ spec:
                      kubectl -n kube-system annotate PrometheusRule prometheus-portworx-rules-portworx.rules.yaml helm.sh/resource-policy=keep --overwrite || true;
                      kubectl -n kube-system annotate ServiceMonitor portworx-prometheus-sm helm.sh/resource-policy=keep --overwrite || true;
                      ']
-
+{{- end }}

--- a/charts/portworx/templates/portworx-operator.yaml
+++ b/charts/portworx/templates/portworx-operator.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.deployOperator }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -95,3 +96,4 @@ spec:
                       - portworx-operator
               topologyKey: "kubernetes.io/hostname"
       serviceAccountName: portworx-operator
+{{- end }}

--- a/charts/portworx/templates/serviceaccount-hook.yaml
+++ b/charts/portworx/templates/serviceaccount-hook.yaml
@@ -6,8 +6,8 @@ metadata:
   name: {{ template "px.hookServiceAccount" . }}
   namespace: kube-system
   annotations:
-    "helm.sh/hook-delete-policy": before-hook-creation
-    "helm.sh/hook": "pre-delete,post-delete,post-install"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook": "post-install,pre-upgrade,pre-delete"
   labels:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
@@ -19,8 +19,8 @@ kind: ClusterRole
 apiVersion: {{ template "rbac.apiVersion" . }}
 metadata:
   annotations:
-    "helm.sh/hook-delete-policy": before-hook-creation
-    "helm.sh/hook": "pre-delete,post-delete,pre-upgrade"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook": "post-install,pre-upgrade,pre-delete"
   name: {{ template "px.hookClusterRole" . }}
 rules:
   # for daemonset to operator migration, we need hooks for all resources deployed by daemonset, due to resources are
@@ -34,8 +34,8 @@ kind: ClusterRoleBinding
 apiVersion: {{ template "rbac.apiVersion" . }}
 metadata:
   annotations:
-    "helm.sh/hook-delete-policy": before-hook-creation
-    "helm.sh/hook": "pre-delete,post-delete"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook": "post-install,pre-upgrade,pre-delete"
   name: {{ template "px.hookClusterRoleBinding" . }}
 subjects:
   - kind: ServiceAccount

--- a/charts/portworx/templates/storage-cluster.yaml
+++ b/charts/portworx/templates/storage-cluster.yaml
@@ -1,4 +1,4 @@
-{{- if not (lookup "apps/v1" "DaemonSet" "kube-system" "portworx") }}
+{{- if and (.Values.deployCluster) (or (not (lookup "apps/v1" "DaemonSet" "kube-system" "portworx")) (default true .Values.generateStorageClusterForMigration)) }}
 
   {{- $isCoreOS := .Values.isTargetOSCoreOS | default false }}
   {{- $internalKVDB := .Values.internalKVDB | default false }}
@@ -38,8 +38,15 @@ metadata:
     {{- if eq $AKSInstall true }}
     portworx.io/is-aks: "true"
     {{- end }}
-    # TODO: remove
+    {{- if (lookup "apps/v1" "Daemonset" "kube-system" "portworx") }}
     portworx.io/migration-approved: "false"
+    {{- end }}
+  labels:
+    heritage: {{.Release.Service | quote }}
+    release: {{.Release.Name | quote }}
+    chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+    app.kubernetes.io/managed-by: {{.Release.Service | quote }}
+    app.kubernetes.io/instance: {{.Release.Name | quote }}
 spec:
   image: portworx/oci-monitor:{{ required "A valid Image tag is required in the SemVer format" .Values.imageVersion }}
   imagePullPolicy: Always
@@ -120,9 +127,9 @@ spec:
   stork:
     {{- if (and (.Values.stork) (eq .Values.stork true))}}
     enabled: true
-      {{- if .Values.storkVersion }}
+    {{- if .Values.storkVersion }}
     image: {{ template "px.getStorkImage" . }}:{{ required "A valid Image tag is required in the SemVer format" .Values.storkVersion }}
-      {{- end }}
+    {{- end }}
     {{- else }}
     enabled: false
     {{- end }}
@@ -152,12 +159,14 @@ spec:
     enabled: true
   {{- end }}
 
+  {{- with .Values.tolerations }}
   placement:
-    {{- with .Values.tolerations }}
     tolerations:
       {{- toYaml . | nindent 4 }}
-    {{- end }}
+  {{- end }}
 
+  {{- if .Values.deleteStrategy.type }}
+  deleteStrategy:
+    type: {{ .Values.deleteStrategy.type }}
+  {{- end }}
 {{- end }}
-
-

--- a/charts/portworx/values.yaml
+++ b/charts/portworx/values.yaml
@@ -1,5 +1,8 @@
 # Please uncomment and specify values for these options as per your requirements.
 
+deployOperator: true                    # Deploy the Portworx operator
+deployCluster: true                     # Deploy the Portworx cluster
+
 deploymentType: oci                     # accepts "oci" or "docker"
 imageType: none                         #
 imageVersion: 2.9.1.4                   # Version of the PX Image.
@@ -22,7 +25,7 @@ managementInterface: none             # Name of the interface <ethX>
 envVars: none                         # NOTE: This is a ";" seperated list of environment variables. For eg: MYENV1=myvalue1;MYENV2=myvalue2
 
 stork: true                           # Use Stork https://docs.portworx.com/scheduler/kubernetes/stork.html for hyperconvergence.
-storkVersion: 2.7.0
+storkVersion:                         # Version of Stork. For eg: 2.7.0
 
 customRegistryURL:
 registrySecret:
@@ -65,3 +68,6 @@ clusterToken:
   serviceAccountName: px-create-cluster-token # Service account name to use for post-install hook to create cluster token
 
 #requirePxEnabledTag: true               # if set to true, portworx will only install on nodes with px/enabled: true label. Not required in most scenarios.
+
+deleteStrategy:                           # Delete strategy for the portworx cluster
+  type:                                   # Valid values: Uninstall, UninstallAndWipe


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
- Support portworx uninstallation using the operator
- Add flags to install operator and storagecluster separately
- Fix annotation in the hook's RBAC objects
- Migration approved annotation needs to be added only if migration is
      needed (DS is present)
- Remove default stork version from values.yaml. This will ensure that the
      operator chooses the right component versions by default

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

