### PR TITLE
Support secure kvdb with operator

### DIFF
--- a/charts/portworx/templates/_helpers.tpl
+++ b/charts/portworx/templates/_helpers.tpl
@@ -227,3 +227,39 @@ Generate a random token for storage provisioning
     {{ "false" | quote }}
 {{- end -}}
 {{- end -}}
+
+{{- define "px.deprecatedKvdbArgs" }}
+{{- $result := "" }}
+{{- if ne .Values.etcd.credentials "none:none" }}
+    {{- $result = printf "%s -userpwd %s" $result .Values.etcd.credentials }}
+{{- end }}
+{{- if ne .Values.etcd.ca "none" }}
+    {{- $result = printf "%s -ca %s" $result .Values.etcd.ca }}
+{{- end }}
+{{- if ne .Values.etcd.cert "none" }}
+    {{- $result = printf "%s -cert %s" $result .Values.etcd.cert }}
+{{- end }}
+{{- if ne .Values.etcd.key "none" }}
+    {{- $result = printf "%s -key %s" $result .Values.etcd.key }}
+{{- end }}
+{{- if ne .Values.consul.token "none" }}
+    {{- $result = printf "%s -acltoken %s" $result .Values.consul.token }}
+{{- end }}
+{{- trim $result }}
+{{- end }}
+
+{{- define "px.miscArgs" }}
+{{- $result := "" }}
+{{- if (include "px.deprecatedKvdbArgs" .) }}
+    {{- $result = printf "%s %s" $result (include "px.deprecatedKvdbArgs" .) }}
+{{- end }}
+{{- trim $result }}
+{{- end }}
+
+{{- define "px.volumesPresent" }}
+{{- $result := false }}
+{{- if (default false .Values.isTargetOSCoreOS) }}
+    {{- $result = true }}
+{{- end }}
+{{- $result }}
+{{- end }}

--- a/charts/portworx/templates/storage-cluster.yaml
+++ b/charts/portworx/templates/storage-cluster.yaml
@@ -3,6 +3,9 @@
   {{- $isCoreOS := .Values.isTargetOSCoreOS | default false }}
   {{- $internalKVDB := .Values.internalKVDB | default false }}
   {{- $etcdEndPoints := .Values.etcdEndPoint }}
+  {{- $etcdCertPath := .Values.etcd.certPath | default "none" }}
+  {{- $etcdCert := .Values.etcd.cert | default "none" }}
+  {{- $etcdKey := .Values.etcd.key | default "none" }}
   {{- $openshiftInstall := .Values.openshiftInstall | default false }}
   {{- $EKSInstall := .Values.EKSInstall | default false }}
   {{- $pksInstall := .Values.pksInstall | default false }}
@@ -19,6 +22,8 @@
   {{- $registrySecret := .Values.registrySecret | default "none" }}
   {{- $licenseSecret := .Values.licenseSecret | default "none" }}
   {{- $kvdbDevice := .Values.kvdbDevice | default "none" }}
+  {{- $miscArgs := include "px.miscArgs" . }}
+  {{- $volumesPresent := include "px.volumesPresent" . }}
 
 kind: StorageCluster
 apiVersion: core.libopenstorage.org/v1
@@ -40,6 +45,9 @@ metadata:
     {{- end }}
     {{- if (lookup "apps/v1" "Daemonset" "kube-system" "portworx") }}
     portworx.io/migration-approved: "false"
+    {{- end }}
+    {{- if $miscArgs }}
+    portworx.io/misc-args: {{ $miscArgs | quote }}
     {{- end }}
   labels:
     heritage: {{.Release.Service | quote }}
@@ -70,6 +78,9 @@ spec:
       {{- range $key, $val := $endpoints }}
       - {{$val}}
       {{- end }}
+    {{- end }}
+    {{- if .Values.kvdb.authSecretName }}
+    authSecret: {{ .Values.kvdb.authSecretName }}
     {{- end }}
   {{- end }}
 
@@ -168,13 +179,32 @@ spec:
     enabled: false
     {{- end }}
 
-  {{- if eq $isCoreOS true}}
+  {{- if eq $volumesPresent "true" }}
   volumes:
-    - name: src
-      mountPath: /lib/modules
-      hostPath:
-        path: /lib/modules
-        type: Directory
+  {{- if eq $isCoreOS true}}
+  - name: src
+    mountPath: /lib/modules
+    hostPath:
+      path: /lib/modules
+      type: Directory
+  {{- end }}
+  {{- if ne $etcdCertPath "none" }}
+  - name: etcdcerts
+    mountPath: /etc/pwx/etcdcerts
+    secret:
+      secretName: px-etcd-certs
+      items:
+      - key: ca.pem
+        path: ca.pem
+      {{- if ne $etcdCert "none" }}
+      - key: client.pem
+        path: client.pem
+      {{- end -}}
+      {{- if ne $etcdKey "none" }}
+      - key: client-key.pem
+        path: client-key.key
+      {{- end -}}
+  {{- end}}
   {{- end }}
 
   {{- if (and (.Values.monitoring) (eq .Values.monitoring true)) }}

--- a/charts/portworx/values.yaml
+++ b/charts/portworx/values.yaml
@@ -42,14 +42,19 @@ aut: false                            # Enable AutoPilot
 internalKVDB: false                   # internal KVDB
 kvdbDevice: none                      # specify a separate device to store KVDB data, only used when internalKVDB is set to true
 
-etcd:
+etcd:                                 # DEPRECATED: Use kvdb.authSecretName for configuring secure etcd
   credentials: none:none              # Username and password for ETCD authentication in the form user:password
   certPath: none                      # Base path where the certificates are placed. (example: if the certificates ca,crt and the key are in /etc/pwx/etcdcerts the value should be provided as /etc/pwx/etcdcerts)
   ca: none                            # Location of CA file for ETCD authentication. Should be /path/to/server.ca
   cert: none                          # Location of certificate for ETCD authentication. Should be /path/to/server.crt
   key: none                           # Location of certificate key for ETCD authentication Should be /path/to/servery.key
-consul:
+
+consul:                               # DEPRECATED: Use kvdb.authSecretName for configuring secure consul
   token: none                         # ACL token value used for Consul authentication. (example: 398073a8-5091-4d9c-871a-bbbeb030d1f6)
+
+kvdb:
+  authSecretName: none                # Refer https://docs.portworx.com/reference/etcd/#securing-with-certificates-in-kubernetes to
+                                      # create a kvdb secret and specify the name of the secret here
 
 tolerations:                          # Add tolerations
   #  - key: "key"


### PR DESCRIPTION
The existing helm chart assumed that the kvdb certs are present in a specific
directory. With operator we want to mount the kvdb certs/creds via a
secret. Kept the existing model to support existing customer migrating from
daemonset, while adding an option to specify kvdb auth secret.

Signed-off-by: Piyush Nimbalkar <pnimbalkar@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

