### PR TITLE
remove lookup as it's not working on k8s 1.22, do not delete hook for…

### DIFF
--- a/charts/portworx/templates/hooks/pre-delete/delete-storagecluster.yaml
+++ b/charts/portworx/templates/hooks/pre-delete/delete-storagecluster.yaml
@@ -17,7 +17,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-weight": "10"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   backoffLimit: 0
   template:

--- a/charts/portworx/templates/hooks/pre-upgrade/retain-daemonset-install.yaml
+++ b/charts/portworx/templates/hooks/pre-upgrade/retain-daemonset-install.yaml
@@ -1,5 +1,3 @@
-{{- if (lookup "apps/v1" "Daemonset" "kube-system" "portworx") }}
-
 {{- $customRegistryURL := .Values.customRegistryURL | default "none" }}
 {{- $registrySecret := .Values.registrySecret | default "none" }}
 
@@ -17,13 +15,8 @@ metadata:
   annotations:
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "10"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
-  {{ if semverCompare ">= 1.8" .Capabilities.KubeVersion.GitVersion }}
-  backoffLimit: 0
-  {{ else }}
-  activeDeadlineSeconds: 30
-  {{ end }}
   template:
     spec:
       {{- if not (eq $registrySecret "none") }}
@@ -42,8 +35,7 @@ spec:
           command: ['/bin/sh',
                     '-c',
                     'kubectl -n kube-system annotate DaemonSet portworx-api helm.sh/resource-policy=keep --overwrite;
-                     kubectl -n kube-system annotate DaemonSet portworx helm.sh/resource-policy=keep --overwrite;
-
+                     kubectl -n kube-system annotate DaemonSet portworx helm.sh/resource-policy=keep --overwrite || true;
                      kubectl -n kube-system annotate Service stork-service helm.sh/resource-policy=keep --overwrite || true;
                      kubectl -n kube-system annotate Service prometheus helm.sh/resource-policy=keep --overwrite || true;
                      kubectl -n kube-system annotate Service portworx-service helm.sh/resource-policy=keep --overwrite || true;
@@ -103,4 +95,3 @@ spec:
                      kubectl -n kube-system annotate PrometheusRule prometheus-portworx-rules-portworx.rules.yaml helm.sh/resource-policy=keep --overwrite || true;
                      kubectl -n kube-system annotate ServiceMonitor portworx-prometheus-sm helm.sh/resource-policy=keep --overwrite || true;
                      ']
-{{- end }}


### PR DESCRIPTION
Lookup does not work on k8s 1.22, so a few changes:
1. Remove lookup, retain-daemonset-install will always be executed, no harm for operator to operator chart upgrade.
2. Do not delete hook when it's succeeded, this is for debugging purpose, in the example above if the hook is deleted it's really hard to tell whether it's deleted or it's never created.
3. Remove backoffLimit and  activeDeadlineSeconds. so if the job fails it will be retried. 