### PR TITLE
Support smooth migration from daemonset wrt encrypted volumes

### DIFF
--- a/charts/portworx/templates/hooks/post-install/px-create-cluster-token.yaml
+++ b/charts/portworx/templates/hooks/post-install/px-create-cluster-token.yaml
@@ -120,7 +120,7 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation
     "helm.sh/hook": post-install
   name: {{ .Values.clusterToken.secretName }}
-  namespace: kube-system
+  namespace: portworx
   labels:
     name: {{ .Values.clusterToken.secretName }}
     heritage: {{ .Release.Service }}

--- a/charts/portworx/templates/portworx-k8s-secrets.yaml
+++ b/charts/portworx/templates/portworx-k8s-secrets.yaml
@@ -5,28 +5,4 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: portworx
----
-kind: Role
-apiVersion: {{ template "rbac.apiVersion" . }}
-metadata:
-  name: px-role
-  namespace: portworx
-rules:
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["get", "list", "create", "update", "patch", "delete"]
----
-kind: RoleBinding
-apiVersion: {{ template "rbac.apiVersion" . }}
-metadata:
-  name: px-role-binding
-  namespace: portworx
-subjects:
-- kind: ServiceAccount
-  name: px-account
-  namespace: kube-system
-roleRef:
-  kind: Role
-  name: px-role
-  apiGroup: rbac.authorization.k8s.io
 {{- end -}}

--- a/charts/portworx/templates/storage-cluster.yaml
+++ b/charts/portworx/templates/storage-cluster.yaml
@@ -189,6 +189,8 @@ spec:
         name: px-azure
         key: AZURE_TENANT_ID
   {{- end }}
+  - name: PX_SECRETS_NAMESPACE
+    value: portworx
 
   stork:
     {{- if (and (.Values.stork) (eq .Values.stork true))}}


### PR DESCRIPTION
Signed-off-by: Piyush Nimbalkar <pnimbalkar@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
This will work for existing daemonset installs as well as new installs. But we ideally want new customers to use the same namespace as StorageCluster to store their secrets. 
And eventually we should just change the default px installation namespace to portworx. This is what we are going to do on spec generator. So, for now, I am keeping `portworx` as the default namespace for secrets, the way it was for daemonset.

**Which issue(s) this PR fixes** (optional)
Closes # https://portworx.atlassian.net/browse/OPERATOR-728

**Special notes for your reviewer**:

