### PR TITLE
Helm: adding index.yaml and releaser workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    # depending on default permission settings for your org (contents being read-only or read-write for workloads), you will have to add permissions
+    # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.5.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          charts_dir: stable
+          charts_repo_url: https://portworx.github.com/charts

--- a/stable/index.yaml
+++ b/stable/index.yaml
@@ -3,7 +3,7 @@ entries:
   portworx:
   - apiVersion: v1
     appVersion: 2.11.4
-    created: "2023-02-15T17:30:37.391468+05:30"
+    created: "2023-03-09T13:17:51.183929-08:00"
     description: A Helm chart for installing Portworx on Kubernetes.
     digest: db0319e7e0aff6a233af0187970a60a431d87f98f961dd4a11e110ef68a8e420
     home: https://portworx.com/
@@ -12,11 +12,11 @@ entries:
     sources:
     - https://github.com/portworx/helm
     urls:
-    - https://raw.githubusercontent.com/portworx/helm/master/stable/portworx-2.11.4.tgz
+    - https://portworx.github.com/charts/portworx-2.11.4.tgz
     version: 2.11.4
   - apiVersion: v1
     appVersion: 2.10.3
-    created: "2023-02-15T17:30:37.390116+05:30"
+    created: "2023-03-09T13:17:51.181897-08:00"
     description: A Helm chart for installing Portworx on Kubernetes.
     digest: 162b316899c5023708ee0edc4083215646fe8c8458d34f79f9f13c2c376e0d0d
     home: https://portworx.com/
@@ -25,11 +25,11 @@ entries:
     sources:
     - https://github.com/portworx/helm
     urls:
-    - https://raw.githubusercontent.com/portworx/helm/master/stable/portworx-2.10.3.tgz
+    - https://portworx.github.com/charts/portworx-2.10.3.tgz
     version: 2.10.3
   - apiVersion: v1
     appVersion: 2.9.1
-    created: "2023-02-15T17:30:37.392911+05:30"
+    created: "2023-03-09T13:17:51.186431-08:00"
     description: A Helm chart for installing Portworx on Kubernetes.
     digest: 71a44b527872750c42c9c39a6e3e03c431e0d74063aa8abf70d11f1401fddad2
     home: https://portworx.com/
@@ -38,10 +38,10 @@ entries:
     sources:
     - https://github.com/portworx/helm
     urls:
-    - https://raw.githubusercontent.com/portworx/helm/master/stable/portworx-2.9.1.tgz
+    - https://portworx.github.com/charts/portworx-2.9.1.tgz
     version: 2.9.1
   - apiVersion: v1
-    created: "2023-02-15T17:30:37.38882+05:30"
+    created: "2023-03-09T13:17:51.179911-08:00"
     description: A Helm chart for installing Portworx on Kubernetes.
     digest: c312df602c509a2c5d60d6197ec137bf8484ecffb3444f1ded6be19964bc3c9f
     home: https://portworx.com/
@@ -50,10 +50,10 @@ entries:
     sources:
     - https://github.com/portworx/helm
     urls:
-    - https://raw.githubusercontent.com/portworx/helm/master/stable/portworx-1.0.1.tgz
+    - https://portworx.github.com/charts/portworx-1.0.1.tgz
     version: 1.0.1
   - apiVersion: v1
-    created: "2023-02-15T17:30:37.386964+05:30"
+    created: "2023-03-09T13:17:51.178116-08:00"
     description: A Helm chart for installing Portworx on Kubernetes.
     digest: ac01a7ae62587285d9a29e2d36c386727eb96694810a563ecf723b21f7582dec
     home: https://portworx.com/
@@ -62,12 +62,12 @@ entries:
     sources:
     - https://github.com/portworx/helm
     urls:
-    - https://raw.githubusercontent.com/portworx/helm/master/stable/portworx-1.0.0.tgz
+    - https://portworx.github.com/charts/portworx-1.0.0.tgz
     version: 1.0.0
   px-backup:
   - apiVersion: v1
     appVersion: 1.2.4
-    created: "2023-02-15T17:30:37.409186+05:30"
+    created: "2023-03-09T13:17:51.206122-08:00"
     description: A Helm chart for installing PX-Backup with PX-Central on Kubernetes
       and Openshift
     digest: 4e1c290efdbd1cf8487e81e4b02b945d2be6aa5b3b9771091214d39c4cd6b868
@@ -85,11 +85,11 @@ entries:
     sources:
     - https://github.com/portworx/helm/tree/master/charts/px-backup
     urls:
-    - https://raw.githubusercontent.com/portworx/helm/master/stable/px-backup-1.2.4.tgz
+    - https://portworx.github.com/charts/px-backup-1.2.4.tgz
     version: 1.2.4
   - apiVersion: v1
     appVersion: 1.2.3
-    created: "2023-02-15T17:30:37.408252+05:30"
+    created: "2023-03-09T13:17:51.204901-08:00"
     description: A Helm chart for installing PX-Backup with PX-Central on Kubernetes
       and Openshift
     digest: 5041aaabb806d9075722c79d34f9dec8f4e80a75f5346d097cb0123417b08c2d
@@ -107,11 +107,11 @@ entries:
     sources:
     - https://github.com/portworx/helm/tree/master/charts/px-backup
     urls:
-    - https://raw.githubusercontent.com/portworx/helm/master/stable/px-backup-1.2.3.tgz
+    - https://portworx.github.com/charts/px-backup-1.2.3.tgz
     version: 1.2.3
   - apiVersion: v1
     appVersion: 1.2.2
-    created: "2023-02-15T17:30:37.407332+05:30"
+    created: "2023-03-09T13:17:51.203598-08:00"
     description: A Helm chart for installing PX-Backup with PX-Central on Kubernetes
       and Openshift
     digest: 5536c872859c726b4dd1cff1bcd21ef4f56903d58fcbbe5b4859b5bd242873cf
@@ -129,11 +129,11 @@ entries:
     sources:
     - https://github.com/portworx/helm/tree/master/charts/px-backup
     urls:
-    - https://raw.githubusercontent.com/portworx/helm/master/stable/px-backup-1.2.2.tgz
+    - https://portworx.github.com/charts/px-backup-1.2.2.tgz
     version: 1.2.2
   - apiVersion: v1
     appVersion: 1.2.1
-    created: "2023-02-15T17:30:37.406387+05:30"
+    created: "2023-03-09T13:17:51.202375-08:00"
     description: A Helm chart for installing PX-Backup with PX-Central on Kubernetes
       and Openshift
     digest: a9b0290cb08d6d3c39adf27ab07be9a17424493980c720223e3a656fa77917ba
@@ -151,11 +151,11 @@ entries:
     sources:
     - https://github.com/portworx/helm/tree/master/charts/px-backup
     urls:
-    - https://raw.githubusercontent.com/portworx/helm/master/stable/px-backup-1.2.1.tgz
+    - https://portworx.github.com/charts/px-backup-1.2.1.tgz
     version: 1.2.1
   - apiVersion: v1
     appVersion: 1.2.0
-    created: "2023-02-15T17:30:37.405406+05:30"
+    created: "2023-03-09T13:17:51.201078-08:00"
     description: A Helm chart for installing PX-Backup with PX-Central on Kubernetes
       and Openshift
     digest: 7f42744f732e8d80793d06189b14f5ed8f7439706db99dd272d96d43a1fd65ab
@@ -173,11 +173,11 @@ entries:
     sources:
     - https://github.com/portworx/helm/tree/master/charts/px-backup
     urls:
-    - https://raw.githubusercontent.com/portworx/helm/master/stable/px-backup-1.2.0.tgz
+    - https://portworx.github.com/charts/px-backup-1.2.0.tgz
     version: 1.2.0
   - apiVersion: v1
     appVersion: 1.1.1
-    created: "2023-02-15T17:30:37.404427+05:30"
+    created: "2023-03-09T13:17:51.199778-08:00"
     description: A Helm chart for installing PX-Backup with PX-Central on Kubernetes
       and Openshift
     digest: 73215fe714e1a3af6bdf958eb06791b90f878b363c85b3adf4c8cfe664a08202
@@ -195,11 +195,11 @@ entries:
     sources:
     - https://github.com/portworx/helm/tree/master/charts/px-backup
     urls:
-    - https://raw.githubusercontent.com/portworx/helm/master/stable/px-backup-1.1.6.tgz
+    - https://portworx.github.com/charts/px-backup-1.1.6.tgz
     version: 1.1.6
   - apiVersion: v1
     appVersion: 1.1.0
-    created: "2023-02-15T17:30:37.402389+05:30"
+    created: "2023-03-09T13:17:51.1985-08:00"
     description: A Helm chart for installing PX-Backup with PX-Central on Kubernetes
       and Openshift
     digest: 6cc1c8df6ddd7e7e49f69db6791f1bdd6b39dc0943f60282fd9212872071103c
@@ -217,11 +217,11 @@ entries:
     sources:
     - https://github.com/portworx/helm/tree/master/charts/px-backup
     urls:
-    - https://raw.githubusercontent.com/portworx/helm/master/stable/px-backup-1.1.5.tgz
+    - https://portworx.github.com/charts/px-backup-1.1.5.tgz
     version: 1.1.5
   - apiVersion: v1
     appVersion: 1.1.0
-    created: "2023-02-15T17:30:37.401396+05:30"
+    created: "2023-03-09T13:17:51.197082-08:00"
     description: A Helm chart for installing PX-Backup with PX-Central on Kubernetes
       and Openshift
     digest: 4115cfbf2e4e8158331bcec3d4404054c9648fb227f6947747f0122ad4f2418a
@@ -239,11 +239,11 @@ entries:
     sources:
     - https://github.com/portworx/helm/tree/master/charts/px-backup
     urls:
-    - https://raw.githubusercontent.com/portworx/helm/master/stable/px-backup-1.1.4.tgz
+    - https://portworx.github.com/charts/px-backup-1.1.4.tgz
     version: 1.1.4
   - apiVersion: v1
     appVersion: 1.1.0-rc4
-    created: "2023-02-15T17:30:37.40045+05:30"
+    created: "2023-03-09T13:17:51.195177-08:00"
     description: A Helm chart for installing PX-Backup with PX-Central on Kubernetes
       and Openshift
     digest: 0121036cb537c93fff9281f05cf935345b5f769017b131b5e903cc4b8354c8ac
@@ -261,11 +261,11 @@ entries:
     sources:
     - https://github.com/portworx/helm/tree/master/charts/px-backup
     urls:
-    - https://raw.githubusercontent.com/portworx/helm/master/stable/px-backup-1.1.3.tgz
+    - https://portworx.github.com/charts/px-backup-1.1.3.tgz
     version: 1.1.3
   - apiVersion: v1
     appVersion: 1.1.0-rc2
-    created: "2023-02-15T17:30:37.399446+05:30"
+    created: "2023-03-09T13:17:51.19398-08:00"
     description: A Helm chart for installing PX-Backup with PX-Central on Kubernetes
       and Openshift
     digest: 96f785bc9ad2c477068d39f351d5c078f080264104ccd6e7630eabae6d0a514c
@@ -283,11 +283,11 @@ entries:
     sources:
     - https://github.com/portworx/helm/tree/master/charts/px-backup
     urls:
-    - https://raw.githubusercontent.com/portworx/helm/master/stable/px-backup-1.1.2.tgz
+    - https://portworx.github.com/charts/px-backup-1.1.2.tgz
     version: 1.1.2
   - apiVersion: v1
     appVersion: 1.1.0-rc2
-    created: "2023-02-15T17:30:37.398449+05:30"
+    created: "2023-03-09T13:17:51.192667-08:00"
     description: A Helm chart for installing PX-Backup with PX-Central on Kubernetes
       and Openshift
     digest: 7167db17211627d3d111441d01c8d71c57a1980c27145dc7c08ebb3ff9f7d548
@@ -305,11 +305,11 @@ entries:
     sources:
     - https://github.com/portworx/helm/tree/master/charts/px-backup
     urls:
-    - https://raw.githubusercontent.com/portworx/helm/master/stable/px-backup-1.1.1.tgz
+    - https://portworx.github.com/charts/px-backup-1.1.1.tgz
     version: 1.1.1
   - apiVersion: v1
     appVersion: 1.1.0-rc1
-    created: "2023-02-15T17:30:37.397461+05:30"
+    created: "2023-03-09T13:17:51.191322-08:00"
     description: A Helm chart for installing PX-Backup with PX-Central on Kubernetes
       and Openshift
     digest: 1a2c71389dc08d58f51f66e3ebe44e63fe7410691ec92d642c0dcfaa57c17605
@@ -327,11 +327,11 @@ entries:
     sources:
     - https://github.com/portworx/helm/tree/master/charts/px-backup
     urls:
-    - https://raw.githubusercontent.com/portworx/helm/master/stable/px-backup-1.1.0.tgz
+    - https://portworx.github.com/charts/px-backup-1.1.0.tgz
     version: 1.1.0
   - apiVersion: v1
     appVersion: 1.0.2
-    created: "2023-02-15T17:30:37.396473+05:30"
+    created: "2023-03-09T13:17:51.190114-08:00"
     description: A Helm chart for installing PX-Backup with PX-Central on Kubernetes
       and Openshift
     digest: fd9316e9719a924eb8aa2d6d947d90e162f602ef4b77e28ef070099fd1dfb1cf
@@ -349,11 +349,11 @@ entries:
     sources:
     - https://github.com/portworx/helm/tree/master/charts/px-backup
     urls:
-    - https://raw.githubusercontent.com/portworx/helm/master/stable/px-backup-1.0.2.tgz
+    - https://portworx.github.com/charts/px-backup-1.0.2.tgz
     version: 1.0.2
   - apiVersion: v1
     appVersion: 1.0.2
-    created: "2023-02-15T17:30:37.395542+05:30"
+    created: "2023-03-09T13:17:51.188973-08:00"
     description: A Helm chart for installing PX-Backup with PX-Central on Kubernetes
       and Openshift
     digest: 0e96c406605816b9a70a0440710d4a82743d373c2b9da20696e6f3a1b1ef2698
@@ -371,11 +371,11 @@ entries:
     sources:
     - https://github.com/portworx/helm/tree/master/charts/px-backup
     urls:
-    - https://raw.githubusercontent.com/portworx/helm/master/stable/px-backup-1.0.1.tgz
+    - https://portworx.github.com/charts/px-backup-1.0.1.tgz
     version: 1.0.1
   - apiVersion: v1
     appVersion: 1.0.2
-    created: "2023-02-15T17:30:37.393986+05:30"
+    created: "2023-03-09T13:17:51.18777-08:00"
     description: A Helm chart for installing PX-Backup with PX-Central on Kubernetes
       and Openshift
     digest: 2bb9b69ade7b648d46ca618f2f798ba0af346022b42ce540d3988b2c8a387226
@@ -393,12 +393,12 @@ entries:
     sources:
     - https://github.com/portworx/helm/tree/master/charts/px-backup
     urls:
-    - https://raw.githubusercontent.com/portworx/helm/master/stable/px-backup-1.0.0.tgz
+    - https://portworx.github.com/charts/px-backup-1.0.0.tgz
     version: 1.0.0
   px-central:
   - apiVersion: v1
     appVersion: 2.3.3
-    created: "2023-02-15T17:30:37.471643+05:30"
+    created: "2023-03-09T13:17:51.277427-08:00"
     description: A Helm chart for installing PX-Central on Kubernetes and Openshift
     digest: 4b2f2dbcd15878e63cb50b21208e8a00317af2566f1b112e11e191fd88183caf
     home: https://portworx.com/
@@ -415,11 +415,11 @@ entries:
     sources:
     - https://github.com/portworx/helm/tree/master/charts/px-central
     urls:
-    - https://raw.githubusercontent.com/portworx/helm/master/stable/px-central-2.3.3.tgz
+    - https://portworx.github.com/charts/px-central-2.3.3.tgz
     version: 2.3.3
   - apiVersion: v1
     appVersion: 2.3.2
-    created: "2023-02-15T17:30:37.466628+05:30"
+    created: "2023-03-09T13:17:51.271984-08:00"
     description: A Helm chart for installing PX-Central on Kubernetes and Openshift
     digest: 07969717a7e2ffd0a85080d1a782d2fbbf2a77b101e4e1e1e48a27c2c1b4a1cf
     home: https://portworx.com/
@@ -436,11 +436,11 @@ entries:
     sources:
     - https://github.com/portworx/helm/tree/master/charts/px-central
     urls:
-    - https://raw.githubusercontent.com/portworx/helm/master/stable/px-central-2.3.2.tgz
+    - https://portworx.github.com/charts/px-central-2.3.2.tgz
     version: 2.3.2
   - apiVersion: v1
     appVersion: 2.3.1
-    created: "2023-02-15T17:30:37.458527+05:30"
+    created: "2023-03-09T13:17:51.265862-08:00"
     description: A Helm chart for installing PX-Central on Kubernetes and Openshift
     digest: bffae73f9f96a3d775084644639b6ec858633a9b377082326756577ca305b2d7
     home: https://portworx.com/
@@ -457,11 +457,11 @@ entries:
     sources:
     - https://github.com/portworx/helm/tree/master/charts/px-central
     urls:
-    - https://raw.githubusercontent.com/portworx/helm/master/stable/px-central-2.3.1.tgz
+    - https://portworx.github.com/charts/px-central-2.3.1.tgz
     version: 2.3.1
   - apiVersion: v1
     appVersion: 2.3.0
-    created: "2023-02-15T17:30:37.452972+05:30"
+    created: "2023-03-09T13:17:51.259033-08:00"
     description: A Helm chart for installing PX-Central on Kubernetes and Openshift
     digest: 849f16762e8c9684d91b9541033c38121f9230975c4f46819e260cbff4ff5212
     home: https://portworx.com/
@@ -478,11 +478,11 @@ entries:
     sources:
     - https://github.com/portworx/helm/tree/master/charts/px-central
     urls:
-    - https://raw.githubusercontent.com/portworx/helm/master/stable/px-central-2.3.0.tgz
+    - https://portworx.github.com/charts/px-central-2.3.0.tgz
     version: 2.3.0
   - apiVersion: v1
     appVersion: 2.2.3
-    created: "2023-02-15T17:30:37.447588+05:30"
+    created: "2023-03-09T13:17:51.253256-08:00"
     description: A Helm chart for installing PX-Central on Kubernetes and Openshift
     digest: 9656fdd92ce4f80ffcaf9e85eaa590c0151f2282da6a536f9722fcb315a993e2
     home: https://portworx.com/
@@ -499,11 +499,11 @@ entries:
     sources:
     - https://github.com/portworx/helm/tree/master/charts/px-central
     urls:
-    - https://raw.githubusercontent.com/portworx/helm/master/stable/px-central-2.2.3.tgz
+    - https://portworx.github.com/charts/px-central-2.2.3.tgz
     version: 2.2.3
   - apiVersion: v1
     appVersion: 2.2.2
-    created: "2023-02-15T17:30:37.442411+05:30"
+    created: "2023-03-09T13:17:51.247641-08:00"
     description: A Helm chart for installing PX-Central on Kubernetes and Openshift
     digest: c4760d4aa90b2f23dff0054c6a57c423f03bdf1e3685c7701025579de77f2d60
     home: https://portworx.com/
@@ -520,11 +520,11 @@ entries:
     sources:
     - https://github.com/portworx/helm/tree/master/charts/px-central
     urls:
-    - https://raw.githubusercontent.com/portworx/helm/master/stable/px-central-2.2.2.tgz
+    - https://portworx.github.com/charts/px-central-2.2.2.tgz
     version: 2.2.2
   - apiVersion: v1
     appVersion: 2.2.1
-    created: "2023-02-15T17:30:37.437474+05:30"
+    created: "2023-03-09T13:17:51.241017-08:00"
     description: A Helm chart for installing PX-Central on Kubernetes and Openshift
     digest: defa0a5d415b35c5f01ebf4ed99aa45a7e3f7ec08c417c415f12dc8bc05ae3a8
     home: https://portworx.com/
@@ -541,11 +541,11 @@ entries:
     sources:
     - https://github.com/portworx/helm/tree/master/charts/px-central
     urls:
-    - https://raw.githubusercontent.com/portworx/helm/master/stable/px-central-2.2.1.tgz
+    - https://portworx.github.com/charts/px-central-2.2.1.tgz
     version: 2.2.1
   - apiVersion: v1
     appVersion: 2.2.0
-    created: "2023-02-15T17:30:37.432374+05:30"
+    created: "2023-03-09T13:17:51.23565-08:00"
     description: A Helm chart for installing PX-Central on Kubernetes and Openshift
     digest: d22206f8b66527c3bf699aab9c3227a5f40065fcb7134207a18813035a1766c2
     home: https://portworx.com/
@@ -562,11 +562,11 @@ entries:
     sources:
     - https://github.com/portworx/helm/tree/master/charts/px-central
     urls:
-    - https://raw.githubusercontent.com/portworx/helm/master/stable/px-central-2.2.0.tgz
+    - https://portworx.github.com/charts/px-central-2.2.0.tgz
     version: 2.2.0
   - apiVersion: v1
     appVersion: 2.1.2
-    created: "2023-02-15T17:30:37.427258+05:30"
+    created: "2023-03-09T13:17:51.229325-08:00"
     description: A Helm chart for installing PX-Central on Kubernetes and Openshift
     digest: 8b45b7ef443c2b02dc41b88b70877f7d83d8180621bf1f708fbbebd8a0dad3bd
     home: https://portworx.com/
@@ -583,11 +583,11 @@ entries:
     sources:
     - https://github.com/portworx/helm/tree/master/charts/px-central
     urls:
-    - https://raw.githubusercontent.com/portworx/helm/master/stable/px-central-2.1.2.tgz
+    - https://portworx.github.com/charts/px-central-2.1.2.tgz
     version: 2.1.2
   - apiVersion: v1
     appVersion: 2.1.1
-    created: "2023-02-15T17:30:37.421769+05:30"
+    created: "2023-03-09T13:17:51.222976-08:00"
     description: A Helm chart for installing PX-Central on Kubernetes and Openshift
     digest: ab68db760b922dfeb49448ab8a5393104d02d92134b2007ffc37932b12dadb5c
     home: https://portworx.com/
@@ -604,11 +604,11 @@ entries:
     sources:
     - https://github.com/portworx/helm/tree/master/charts/px-central
     urls:
-    - https://raw.githubusercontent.com/portworx/helm/master/stable/px-central-2.1.1.tgz
+    - https://portworx.github.com/charts/px-central-2.1.1.tgz
     version: 2.1.1
   - apiVersion: v1
     appVersion: 2.0.1
-    created: "2023-02-15T17:30:37.418015+05:30"
+    created: "2023-03-09T13:17:51.217207-08:00"
     description: A Helm chart for installing PX-Central on Kubernetes and Openshift
     digest: f719f6251797b14ffad588f8db5648cd9f515e0bf855c487804f4a731f26f8cb
     home: https://portworx.com/
@@ -625,11 +625,11 @@ entries:
     sources:
     - https://github.com/portworx/helm/tree/master/charts/px-central
     urls:
-    - https://raw.githubusercontent.com/portworx/helm/master/stable/px-central-2.0.1.tgz
+    - https://portworx.github.com/charts/px-central-2.0.1.tgz
     version: 2.0.1
   - apiVersion: v1
     appVersion: 2.0.0
-    created: "2023-02-15T17:30:37.413474+05:30"
+    created: "2023-03-09T13:17:51.211709-08:00"
     description: A Helm chart for installing PX-Central on Kubernetes and Openshift
     digest: 58adcc335f387a3090cd55316ca7f2f4ebedaeea1375764d1bf18582551d4d96
     home: https://portworx.com/
@@ -646,12 +646,12 @@ entries:
     sources:
     - https://github.com/portworx/helm/tree/master/charts/px-central
     urls:
-    - https://raw.githubusercontent.com/portworx/helm/master/stable/px-central-2.0.0.tgz
+    - https://portworx.github.com/charts/px-central-2.0.0.tgz
     version: 2.0.0
   px-license-server:
   - apiVersion: v1
     appVersion: 1.0.0
-    created: "2023-02-15T17:30:37.47483+05:30"
+    created: "2023-03-09T13:17:51.281607-08:00"
     description: A Helm chart for install and configure PX-License-Server on Kubernetes
       and Openshift
     digest: 70a52d0e5a59dfcbdabba7dda742d748d42937aecb4cdd8f603738cbbfb2c8a4
@@ -664,11 +664,11 @@ entries:
     sources:
     - https://github.com/portworx/helm/tree/master/charts/px-license-server
     urls:
-    - https://raw.githubusercontent.com/portworx/helm/master/stable/px-license-server-1.2.1.tgz
+    - https://portworx.github.com/charts/px-license-server-1.2.1.tgz
     version: 1.2.1
   - apiVersion: v1
     appVersion: 1.0.0
-    created: "2023-02-15T17:30:37.474165+05:30"
+    created: "2023-03-09T13:17:51.281014-08:00"
     description: A Helm chart for install and configure PX-License-Server on Kubernetes
       and Openshift
     digest: 5ee27e632cc313ab281a50c2deebbd8713657d19e0b394ea97ae4fdee76f4f09
@@ -681,11 +681,11 @@ entries:
     sources:
     - https://github.com/portworx/helm/tree/master/charts/px-license-server
     urls:
-    - https://raw.githubusercontent.com/portworx/helm/master/stable/px-license-server-1.2.0.tgz
+    - https://portworx.github.com/charts/px-license-server-1.2.0.tgz
     version: 1.2.0
   - apiVersion: v1
     appVersion: 1.0.0
-    created: "2023-02-15T17:30:37.473566+05:30"
+    created: "2023-03-09T13:17:51.280329-08:00"
     description: A Helm chart for install and configure PX-License-Server on Kubernetes
       and Openshift
     digest: 55f496792430763626acecb5082eaff7c5276879a0f527ae993635ad8ac90640
@@ -698,11 +698,11 @@ entries:
     sources:
     - https://github.com/portworx/helm/tree/master/charts/px-license-server
     urls:
-    - https://raw.githubusercontent.com/portworx/helm/master/stable/px-license-server-1.1.0.tgz
+    - https://portworx.github.com/charts/px-license-server-1.1.0.tgz
     version: 1.1.0
   - apiVersion: v1
     appVersion: 1.0.1
-    created: "2023-02-15T17:30:37.47288+05:30"
+    created: "2023-03-09T13:17:51.279628-08:00"
     description: A Helm chart for install and configure PX-License-Server on Kubernetes
       and Openshift
     digest: 6673a056155f5329ef7c8cf2c4436668af4b023d234d004448e1db8a2696e1f1
@@ -715,11 +715,11 @@ entries:
     sources:
     - https://github.com/portworx/helm/tree/master/charts/px-license-server
     urls:
-    - https://raw.githubusercontent.com/portworx/helm/master/stable/px-license-server-1.0.1.tgz
+    - https://portworx.github.com/charts/px-license-server-1.0.1.tgz
     version: 1.0.1
   - apiVersion: v1
     appVersion: 1.0.0
-    created: "2023-02-15T17:30:37.472245+05:30"
+    created: "2023-03-09T13:17:51.278637-08:00"
     description: A Helm chart for install and configure PX-License-Server on Kubernetes
       and Openshift
     digest: bb595272c93ef8071e8bc606a3cf8bdb5d7099646d4f8066748f9bd57ac76af1
@@ -732,12 +732,12 @@ entries:
     sources:
     - https://github.com/portworx/helm/tree/master/charts/px-license-server
     urls:
-    - https://raw.githubusercontent.com/portworx/helm/master/stable/px-license-server-1.0.0.tgz
+    - https://portworx.github.com/charts/px-license-server-1.0.0.tgz
     version: 1.0.0
   px-monitor:
   - apiVersion: v1
     appVersion: 1.2.1
-    created: "2023-02-15T17:30:37.4862+05:30"
+    created: "2023-03-09T13:17:51.29523-08:00"
     description: A Helm chart for install and configure PX-Monitor on Kubernetes and
       Openshift
     digest: 9ecba7fb39e84dbdf274784b509780465bda9b0b0c0574b7e729f5575a4a4a1e
@@ -753,11 +753,11 @@ entries:
     sources:
     - https://github.com/portworx/helm/tree/master/charts/px-monitor
     urls:
-    - https://raw.githubusercontent.com/portworx/helm/master/stable/px-monitor-1.2.1.tgz
+    - https://portworx.github.com/charts/px-monitor-1.2.1.tgz
     version: 1.2.1
   - apiVersion: v1
     appVersion: 1.2.0
-    created: "2023-02-15T17:30:37.483466+05:30"
+    created: "2023-03-09T13:17:51.292238-08:00"
     description: A Helm chart for install and configure PX-Monitor on Kubernetes and
       Openshift
     digest: ed29de40a6aedebd2df7cce93084cf008b565d72cc36bcaf92c33048a920fade
@@ -773,11 +773,11 @@ entries:
     sources:
     - https://github.com/portworx/helm/tree/master/charts/px-monitor
     urls:
-    - https://raw.githubusercontent.com/portworx/helm/master/stable/px-monitor-1.2.0.tgz
+    - https://portworx.github.com/charts/px-monitor-1.2.0.tgz
     version: 1.2.0
   - apiVersion: v1
     appVersion: 1.1.1
-    created: "2023-02-15T17:30:37.480545+05:30"
+    created: "2023-03-09T13:17:51.288119-08:00"
     description: A Helm chart for install and configure PX-Monitor on Kubernetes and
       Openshift
     digest: 66e6d465883dc5be2b6413cb09809aa48cc898400c5e149cf8ead44ed84ec504
@@ -793,11 +793,11 @@ entries:
     sources:
     - https://github.com/portworx/helm/tree/master/charts/px-monitor
     urls:
-    - https://raw.githubusercontent.com/portworx/helm/master/stable/px-monitor-1.1.1.tgz
+    - https://portworx.github.com/charts/px-monitor-1.1.1.tgz
     version: 1.1.1
   - apiVersion: v1
     appVersion: 1.1.0
-    created: "2023-02-15T17:30:37.477827+05:30"
+    created: "2023-03-09T13:17:51.284476-08:00"
     description: A Helm chart for install and configure PX-Monitor on Kubernetes and
       Openshift
     digest: 079c699ed5fcba8f9214bde2b9f7b641883bac7cb57d3075a796583a10a2f9ed
@@ -813,6 +813,6 @@ entries:
     sources:
     - https://github.com/portworx/helm/tree/master/charts/px-monitor
     urls:
-    - https://raw.githubusercontent.com/portworx/helm/master/stable/px-monitor-1.1.0.tgz
+    - https://portworx.github.com/charts/px-monitor-1.1.0.tgz
     version: 1.1.0
-generated: "2023-02-15T17:30:37.385345+05:30"
+generated: "2023-03-09T13:17:51.175535-08:00"


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Helm charts should be made available at a helm compatible repo URL, where users can `helm repo add` / `helm install`.

Using [this example repo as a template](https://github.com/technosophos/tscharts), GitHub Pages can be used as a helm repo to serve charts with specific versions.

[Chart Releaser](https://github.com/helm/chart-releaser-action) action is used to create releases and update the `index.yaml` file for the self-hosted repo.

There is documentation out there for enabling GitHub Pages for the purposes of serving helm charts.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

Please enable GitHub Pages for this repo to make it a helm compatible repo.
