### PR TITLE
PWX-31085: containerd DS fixes

### DIFF
--- a/charts/portworx-daemonSet/templates/portworx-ds.yaml
+++ b/charts/portworx-daemonSet/templates/portworx-ds.yaml
@@ -1,5 +1,7 @@
 {{/* Setting defaults if they are omitted. */}}
 {{- $deployEnvironmentIKS := .Capabilities.KubeVersion.GitVersion | regexMatch "IKS" }}
+{{- $deployEnvironmentK3S := .Capabilities.KubeVersion.GitVersion | regexMatch "k3s" }}
+{{- $deployEnvironmentRKE2 := .Capabilities.KubeVersion.GitVersion | regexMatch "rke2" }}
 {{- $usefileSystemDrive := .Values.usefileSystemDrive | default false }}
 {{- $drives := .Values.drives | default "none" }}
 {{- $usedrivesAndPartitions := .Values.usedrivesAndPartitions | default false }}
@@ -265,6 +267,8 @@ spec:
               mountPath: /var/run/docker.sock
             - name: containerdsock
               mountPath: /run/containerd
+            - name: containerdvardir
+              mountPath: /var/lib/containerd
             - name: criosock
               mountPath: /var/run/crio
             - name: etcpwx
@@ -328,6 +332,15 @@ spec:
               mountPath: /usr/src
           {{- end }}
           {{- end }}
+          {{- if or $deployEnvironmentK3S $deployEnvironmentRKE2 }}
+            - name: containerd-k3s
+              mountPath: /run/containerd/containerd.sock
+            - name: containerddir-k3s
+              mountPath: /var/lib/rancher
+          {{- else if $deployEnvironmentIKS }}
+            - name: cripersistentstorage-iks
+              mountPath: /var/data/cripersistentstorage
+          {{- end }}
 
           {{- if eq $csi true }}
         - name: csi-node-driver-registrar
@@ -385,6 +398,9 @@ spec:
         - name: containerdsock
           hostPath:
             path: {{if eq $pksInstall true}}/var/vcap/sys/run/containerd{{else}}/run/containerd{{end}}
+        - name: containerdvardir
+          hostPath:
+            path: {{if eq $pksInstall true}}/var/vcap/store/containerd{{else}}/var/lib/containerd{{end}}
         - name: criosock
           hostPath:
             path: {{if eq $pksInstall true}}/var/vcap/sys/run/crio{{else}}/var/run/crio{{end}}
@@ -457,6 +473,18 @@ spec:
         - name: hostproc
           hostPath:
             path: /proc
+        {{- end }}
+        {{- if or $deployEnvironmentK3S $deployEnvironmentRKE2 }}
+        - name: containerd-k3s
+          hostPath:
+            path: /run/k3s/containerd/containerd.sock
+        - name: containerddir-k3s
+          hostPath:
+            path: /var/lib/rancher
+        {{- else if $deployEnvironmentIKS }}
+        - name: cripersistentstorage-iks
+          hostPath:
+            path: /var/data/cripersistentstorage
         {{- end }}
 ---
 apiVersion: apps/v1


### PR DESCRIPTION
Daemonset YAML for px-3.0.0 and containerd deployment fixes:
* generic deployment fix  (need new /var/lib/containerd mount)
* adds support for K3s and RKE2 distros  (new custom containerd.sock and /var/lib/rancher mounts)
* adds support for IKS on containerd  (new /var/data/cripersistentstorage mount)

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

The px-3.0.0 uses updated `containerd` client API, which requires more mounts to be brought into the "portworx POD" container.

**Which issue(s) this PR fixes** (optional)
Closes # PWX-31085

**Special notes for your reviewer**:

Testing notes:

* testing deployments using "dry-run" to generate the YAML's:
```
helm install --debug --dry-run \
  --set etcdEndPoint=etcd:http://192.168.70.90:2379,clusterName=4BEF1378 \
  foobar123 ./charts/portworx-daemonSet
```

* general deployment -- uses extra `/var/lib/containerd` mount:

```
...
          volumeMounts:
            - name: containerdsock
              mountPath: /run/containerd
            - name: containerdvardir
              mountPath: /var/lib/containerd
	      ...
      volumes:
        - name: containerdsock
          hostPath:
            path: /run/containerd
        - name: containerdvardir
          hostPath:
            path: /var/lib/containerd
	...
```

* forcing K3s/RKE2 deployment --
   - adds custom `containerd.sock` and `/var/lib/rancher`

```
...
          volumeMounts:
            - name: containerdsock
              mountPath: /run/containerd
            - name: containerdvardir
              mountPath: /var/lib/containerd
            ...
              mountPath: /var/run/dbus
            - name: containerd-k3s
              mountPath: /run/containerd/containerd.sock
            - name: containerddir-k3s
              mountPath: /var/lib/rancher
      volumes:
        - name: containerdsock
          hostPath:
            path: /run/containerd
        - name: containerdvardir
          hostPath:
            path: /var/lib/containerd
	...
        - name: containerd-k3s
          hostPath:
            path: /run/k3s/containerd/containerd.sock
        - name: containerddir-k3s
          hostPath:
            path: /var/lib/rancher
```

* forcing IKS deployment -- note, using new `/var/data/cripersistentstorage` mount :

```
...
          volumeMounts:
            - name: containerdsock
              mountPath: /run/containerd
            - name: containerdvardir
              mountPath: /var/lib/containerd
            ...
            - name: cripersistentstorage-iks
              mountPath: /var/data/cripersistentstorage

      volumes:
        - name: containerdsock
          hostPath:
            path: /run/containerd
        - name: containerdvardir
          hostPath:
            path: /var/lib/containerd
        ...
        - name: cripersistentstorage-iks
          hostPath:
            path: /var/data/cripersistentstorage
```

* forcing PKS -- note, using modified `/var/vcap/store/containerd` mount:

```
...
          volumeMounts:
            - name: containerdsock
              mountPath: /run/containerd
            - name: containerdvardir
              mountPath: /var/lib/containerd
	    ...
      volumes:
        - name: containerdsock
          hostPath:
            path: /var/vcap/sys/run/containerd
        - name: containerdvardir
          hostPath:
            path: /var/vcap/store/containerd
	...
```