### PR TITLE
PB-4200 | Add Cache-Control headers for backup UI index page

### DIFF
--- a/charts/px-central/templates/px-lighthouse/px-central-ui/pxcentral-ui.yaml
+++ b/charts/px-central/templates/px-lighthouse/px-central-ui/pxcentral-ui.yaml
@@ -52,6 +52,7 @@ data:
       server_tokens off;
       location / {
         root   /usr/share/nginx/html;
+        add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate";
         index  index.html index.htm;
       }
 


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes # https://portworx.atlassian.net/browse/PB-4200

**Special notes for your reviewer**:

> Tested that index page is never cached. This is ensured by adding a Cache-Control header for index page in nginx.conf file.

> Adding query param in URL (part of this PR) to ensure that the cached page is not used after upgrade.

> Checked that none of the invocations of openUrl method (in which the change has been made) passes query param. So hard-coding `?v=2-5-2` in the method will not break anything.

> This is an interim solution. Will ensure in the next release that, 1) we cache-bust properly without the need for this query param and 2) never reload the entire app on navigating within the app (instead just use Angular SPA based routing).


https://github.com/pure-px/pxcentral-onprem-ui/assets/131302497/5c4cf41f-2657-4809-afad-1718d58f1741


