### PR TITLE
PWX-31983 Fixing k8s version issue

### DIFF
--- a/charts/portworx/Chart.yaml
+++ b/charts/portworx/Chart.yaml
@@ -1,7 +1,7 @@
 name: portworx
 version: 3.0.0
 description: A Helm chart for installing Portworx on Kubernetes.
-kubeVersion: ">=1.10.0"
+kubeVersion: ">=1.21.0-0"
 appVersion: "3.0.0"
 apiVersion: v1
 keywords:


### PR DESCRIPTION
Fixing k8s version issue when k8s version has `-` in the version string

**NOTE:** Also bumping up minimum k8s version to 1.21

Before
```
$ helm upgrade --debug --kubeconfig kubeconfig portworx-test helm/charts/portworx/ --dry-run
WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: kubeconfig
WARNING: Kubernetes configuration file is world-readable. This is insecure. Location: kubeconfig
upgrade.go:150: [debug] preparing upgrade for portworx-test
Error: UPGRADE FAILED: chart requires kubeVersion: >=1.21.0 which is incompatible with Kubernetes v1.27.4-eks-2d98532
helm.go:84: [debug] chart requires kubeVersion: >=1.21.0 which is incompatible with Kubernetes v1.27.4-eks-2d98532
```

After

```
$ helm upgrade --debug --kubeconfig kubeconfig portworx-test helm/charts/portworx/ --dry-run
WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: kubeconfig
WARNING: Kubernetes configuration file is world-readable. This is insecure. Location: kubeconfig
upgrade.go:150: [debug] preparing upgrade for portworx-test
upgrade.go:158: [debug] performing update for portworx-test
upgrade.go:321: [debug] dry run for portworx-test
Release "portworx-test" has been upgraded. Happy Helming!
```

**NOTE:** Tested this on various k8s versions like `v1.27.2`, `v1.27.5+rke2r1` and `v1.27.4-eks-8ccc7ba`