### PR TITLE
PB-4876: Log resource permission for px-backup

### DIFF
--- a/charts/px-central/templates/px-backup/pxcentral-backup.yaml
+++ b/charts/px-central/templates/px-backup/pxcentral-backup.yaml
@@ -94,6 +94,9 @@ rules:
     resources: ["pods"]
     verbs: ["get", "list"]
   - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
     resources: ["events"]
     verbs: ["get", "list"]
 {{- end }}


### PR DESCRIPTION


**What this PR does / why we need it**:
For pb-4876 task, Logs from backup sync job pod is added to px-backup logs for debugging in scenarios of Job succeed, job failed, or pod not running

**Which issue(s) this PR fixes** 
[https://portworx.atlassian.net/browse/PB-4876](PB-4876)
