### PR TITLE
PB-5064: Updated prometheus/alertmanager with latest images and to support basic auth

### DIFF
--- a/charts/px-central/templates/px-backup/pxcentral-alertmanager.yaml
+++ b/charts/px-central/templates/px-backup/pxcentral-alertmanager.yaml
@@ -9,6 +9,43 @@ spec:
       app: px-backup-alert-configs
   replicas: {{ .Values.pxbackup.alertmanager.replicas }}
   retention: {{ .Values.pxbackup.alertmanager.retention}}
+  containers:
+    - args:
+        - '--config.file=/etc/alertmanager/config_out/alertmanager.env.yaml'
+        - '--storage.path=/alertmanager'
+        - '--data.retention={{ .Values.pxbackup.alertmanager.retention }}'
+        - '--cluster.listen-address=[$(POD_IP)]:9094'
+        - '--web.listen-address=127.0.0.1:9093'
+        - '--web.route-prefix=/'
+        - '--cluster.label={{ .Release.Namespace }}/px-backup-alertmanager'
+        - '--cluster.peer=alertmanager-px-backup-alertmanager-0.alertmanager-operated:9094'
+        - '--cluster.peer=alertmanager-px-backup-alertmanager-1.alertmanager-operated:9094'
+        - '--cluster.reconnect-timeout=5m'
+        - '--web.config.file=/etc/alertmanager/web_config/web-config-custom.yaml'
+      env:
+        - name: AUTH_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: pxc-backup-metrics
+              key: metrics-secret
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+      image: {{ printf "%s/%s/%s:%s" .Values.images.pxBackupAlertmanagerImage.registry .Values.images.pxBackupAlertmanagerImage.repo .Values.images.pxBackupAlertmanagerImage.imageName .Values.images.pxBackupAlertmanagerImage.tag }}
+      name: alertmanager
+  listenLocal: true
+  volumeMounts:
+    - mountPath: /etc/alertmanager/web_config/web-config-custom.yaml
+      name: web-config-custom
+      readOnly: true
+      subPath: web-config-custom.yaml
+  volumes:
+    - name: web-config-custom
+      secret:
+        defaultMode: 420
+        secretName: pxc-backup-metrics
   {{- if .Values.persistentStorage.storageClassName }}
   storage:
     volumeClaimTemplate:
@@ -17,4 +54,4 @@ spec:
         resources:
           requests:
             storage: {{ .Values.persistentStorage.prometheus.storage }}
-  {{- end }}  
+  {{- end }}

--- a/charts/px-central/templates/px-backup/pxcentral-prometheus.yaml
+++ b/charts/px-central/templates/px-backup/pxcentral-prometheus.yaml
@@ -4,7 +4,7 @@ kind: ClusterRoleBinding
 metadata:
   name: prometheus-operator
   namespace: {{ .Release.Namespace }}
-  labels:                    
+  labels:
     app.kubernetes.io/component: px-backup
 {{- include "px-central.labels" . | nindent 4 }}
 subjects:
@@ -39,6 +39,7 @@ rules:
       - monitoring.coreos.com
     resources:
         - alertmanagers
+        - alertmanagers/status
         - prometheuses
         - prometheuses/finalizers
         - prometheuses/status
@@ -76,7 +77,7 @@ rules:
     resources:
       - namespaces
     verbs: ["list", "watch", "get"]
-  
+
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -110,9 +111,8 @@ spec:
       - args:
           - -namespaces={{ .Release.Namespace }}
           - --kubelet-service={{ .Release.Namespace }}/kubelet
-          - --prometheus-config-reloader={{ printf "%s/%s/%s:%s" .Values.images.prometheusConfigReloadrImage.registry .Values.images.prometheusConfigReloadrImage.repo .Values.images.prometheusConfigReloadrImage.imageName .Values.images.prometheusConfigReloadrImage.tag }}
-        image: {{ printf "%s/%s/%s:%s" .Values.images.prometheusOperatorImage.registry .Values.images.prometheusOperatorImage.repo .Values.images.prometheusOperatorImage.imageName .Values.images.prometheusOperatorImage.tag }}
-        imagePullPolicy: {{ .Values.imagePullPolicy }}
+          - --prometheus-config-reloader={{ printf "%s/%s/%s:%s" .Values.images.pxBackupPrometheusConfigReloaderImage.registry .Values.images.pxBackupPrometheusConfigReloaderImage.repo .Values.images.pxBackupPrometheusConfigReloaderImage.imageName .Values.images.pxBackupPrometheusConfigReloaderImage.tag }}
+        image: {{ printf "%s/%s/%s:%s" .Values.images.pxBackupPometheusOperatorImage.registry .Values.images.pxBackupPometheusOperatorImage.repo .Values.images.pxBackupPometheusOperatorImage.imageName .Values.images.pxBackupPometheusOperatorImage.tag }}
         name: prometheus-operator
         ports:
           - containerPort: 8080
@@ -132,7 +132,7 @@ spec:
       {{- with .Values.tolerations }}
       tolerations:
       {{- toYaml . | nindent 8 }}
-      {{- end }} 
+      {{- end }}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -235,6 +235,22 @@ spec:
       app: px-backup
 
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/component: pxc-backup-metrics
+{{- include "px-central.labels" . | nindent 4 }}
+  name: pxc-backup-metrics
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+stringData:
+  metrics-secret: "YWRtaW46ZTFacEtheTczTnVW"
+  web-config-custom.yaml: |
+    basic_auth_users:
+      admin: $2a$12$EUVIFCn0M6cGdR612WlqSOFkj48VkxxlK.ElcgTZUjroOauS6MH3C
+
+---
 apiVersion: monitoring.coreos.com/v1
 kind: Prometheus
 metadata:
@@ -250,6 +266,46 @@ spec:
           requests:
             storage: {{ .Values.persistentStorage.prometheus.storage }}
   {{- end }}
+  containers:
+  - args:
+    - --web.console.templates=/etc/prometheus/consoles
+    - --web.console.libraries=/etc/prometheus/console_libraries
+    - --storage.tsdb.retention.time={{ .Values.pxbackup.prometheus.retention }}
+    - --config.file=/etc/prometheus/config_out/prometheus.env.yaml
+    - --storage.tsdb.path=/prometheus
+    - --web.enable-lifecycle
+    - --web.route-prefix=/
+    - --log.level=debug
+    - --web.config.file=/etc/prometheus/web_config/web-config-custom.yaml
+    env:
+    - name: AUTH_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: pxc-backup-metrics
+          key: metrics-secret
+    image: {{ printf "%s/%s/%s:%s" .Values.images.pxBackupPrometheusImage.registry .Values.images.pxBackupPrometheusImage.repo .Values.images.pxBackupPrometheusImage.imageName .Values.images.pxBackupPrometheusImage.tag }}
+    livenessProbe:
+      exec:
+        command:
+        - sh
+        - -c
+        - wget http://localhost:9090/-/healthy --header="Authorization:Basic $AUTH_SECRET"
+          -qO-
+    name: prometheus
+    readinessProbe:
+      exec:
+        command:
+        - sh
+        - -c
+        - wget http://localhost:9090/-/ready --header="Authorization:Basic $AUTH_SECRET"
+          -qO-
+    startupProbe:
+      exec:
+        command:
+        - sh
+        - -c
+        - wget http://localhost:9090/-/ready --header="Authorization:Basic $AUTH_SECRET"
+          -qO-
   securityContext:
     fsGroup: 2000
     runAsNonRoot: true
@@ -260,6 +316,17 @@ spec:
       namespace: {{ .Release.Namespace }}
       port: web
   logLevel: debug
+  listenLocal: true
+  volumeMounts:
+    - mountPath: /etc/prometheus/web_config/web-config-custom.yaml
+      name: web-config-custom
+      readOnly: true
+      subPath: web-config-custom.yaml
+  volumes:
+    - name: web-config-custom
+      secret:
+        defaultMode: 420
+        secretName: pxc-backup-metrics
   replicas: {{ .Values.pxbackup.prometheus.replicas }}
   ruleSelector:
     matchLabels:
@@ -277,4 +344,4 @@ spec:
   {{- with .Values.tolerations }}
   tolerations:
   {{- toYaml . | nindent 4 }}
-  {{- end }} 
+  {{- end }}

--- a/charts/px-central/values.yaml
+++ b/charts/px-central/values.yaml
@@ -57,7 +57,7 @@ pxbackup:
     retention: 90d
   alertmanager:
     replicas: 2
-    retention: 24h
+    retention: 720h
   nfs:
     enabled: true
 
@@ -246,6 +246,26 @@ images:
     repo: portworx
     imageName: prometheus
     tag: v2.35.0
+  pxBackupPrometheusImage:
+    registry: docker.io
+    repo: portworx
+    imageName: prometheus
+    tag: v2.48.0
+  pxBackupAlertmanagerImage:
+    registry: docker.io
+    repo: portworx
+    imageName: alertmanager
+    tag: v0.26.0
+  pxBackupPometheusOperatorImage:
+    registry: docker.io
+    repo: portworx
+    imageName: prometheus-operator
+    tag: v0.70.0
+  pxBackupPrometheusConfigReloaderImage:
+    registry: docker.io
+    repo: portworx
+    imageName: prometheus-config-reloader
+    tag: v0.70.0
   prometheusConfigReloadrImage:
     registry: docker.io
     repo: portworx


### PR DESCRIPTION


<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: This PR has the changes to use latest images for prometheus/alertmanager and support for having basic auth

**Which issue(s) this PR fixes** (optional)
Closes # https://portworx.atlassian.net/browse/PB-5064

**Special notes for your reviewer**:

