### PR TITLE
PWX-35781 : Updating storagecluster crd to same as operator v23.10.5

### DIFF
--- a/charts/portworx/crds/core_v1_storagecluster_crd.yaml
+++ b/charts/portworx/crds/core_v1_storagecluster_crd.yaml
@@ -130,6 +130,13 @@ spec:
                     type: object
                     description: Spec to control the desired behavior of storage cluster rolling update.
                     properties:
+                      minReadySeconds:
+                        description: Minimum number of seconds for which a newly created Portworx pod
+                          should be ready without any of its container crashing for it to
+                          be considered available. Defaults to 0 (pod will be considered available
+                          as soon as it is ready).
+                        format: int32
+                        type: integer
                       maxUnavailable:
                         x-kubernetes-int-or-string: true
                         description: >-
@@ -623,6 +630,30 @@ spec:
                                               type: string
                                             mode:
                                               type: integer
+                  resources:
+                    type: object
+                    description: Specifies the resource requirements for stork and stork scheduler.
+                    properties:
+                      requests:
+                        type: object
+                        description: Requested resources.
+                        properties:
+                          memory:
+                            type: string
+                            description: Requested memory.
+                          cpu:
+                            type: string
+                            description: Requested cpu.
+                      limits:
+                        type: object
+                        description: Resource limit.
+                        properties:
+                          memory:
+                            type: string
+                            description: Memory limit.
+                          cpu:
+                            type: string
+                            description: CPU limit.
               userInterface:
                 type: object
                 description: Contains spec of a user interface for the storage driver.
@@ -876,6 +907,30 @@ spec:
                           type: object
                           x-kubernetes-preserve-unknown-fields: true
                           description: Map of key-value params for the provider.
+                  resources:
+                    type: object
+                    description: Specifies the resource requirements for the autopilot pod.
+                    properties:
+                      requests:
+                        type: object
+                        description: Requested resources.
+                        properties:
+                          memory:
+                            type: string
+                            description: Requested memory.
+                          cpu:
+                            type: string
+                            description: Requested cpu.
+                      limits:
+                        type: object
+                        description: Resource limit.
+                        properties:
+                          memory:
+                            type: string
+                            description: Memory limit.
+                          cpu:
+                            type: string
+                            description: CPU limit.
               monitoring:
                 type: object
                 description: Contains monitoring configuration for the storage cluster.
@@ -888,6 +943,158 @@ spec:
                     type: object
                     description: Contains configuration of Prometheus to monitor the storage cluster.
                     properties:
+                      resources:
+                        type: object
+                        description: Define resources requests and limits for single Pods.
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute resources
+                              allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of compute
+                              resources required. If Requests is omitted for a container,
+                              it defaults to Limits if that is explicitly specified, otherwise
+                              to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                      securityContext:
+                        description: 'Security options the pod should run with. More
+                          info: https://kubernetes.io/docs/concepts/policy/security-context/
+                          More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                        properties:
+                          allowPrivilegeEscalation:
+                            description: 'AllowPrivilegeEscalation controls whether
+                              a process can gain more privileges than its parent process.
+                              This bool directly controls if the no_new_privs flag will
+                              be set on the container process. AllowPrivilegeEscalation
+                              is true always when the container is: 1) run as Privileged
+                              2) has CAP_SYS_ADMIN'
+                            type: boolean
+                          capabilities:
+                            description: The capabilities to add/drop when running containers.
+                              Defaults to the default set of capabilities granted by
+                              the container runtime.
+                            properties:
+                              add:
+                                description: Added capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
+                                  type: string
+                                type: array
+                              drop:
+                                description: Removed capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
+                                  type: string
+                                type: array
+                            type: object
+                          privileged:
+                            description: Run container in privileged mode. Processes
+                              in privileged containers are essentially equivalent to
+                              root on the host. Defaults to false.
+                            type: boolean
+                          procMount:
+                            description: procMount denotes the type of proc mount to
+                              use for the containers. The default is DefaultProcMount
+                              which uses the container runtime defaults for readonly
+                              paths and masked paths. This requires the ProcMountType
+                              feature flag to be enabled.
+                            type: string
+                          readOnlyRootFilesystem:
+                            description: Whether this container has a read-only root
+                              filesystem. Default is false.
+                            type: boolean
+                          runAsGroup:
+                            description: The GID to run the entrypoint of the container
+                              process. Uses runtime default if unset. May also be set
+                              in PodSecurityContext.  If set in both SecurityContext
+                              and PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            description: Indicates that the container must run as a
+                              non-root user. If true, the Kubelet will validate the
+                              image at runtime to ensure that it does not run as UID
+                              0 (root) and fail to start the container if it does. If
+                              unset or false, no such validation will be performed.
+                              May also be set in PodSecurityContext.  If set in both
+                              SecurityContext and PodSecurityContext, the value specified
+                              in SecurityContext takes precedence.
+                            type: boolean
+                          runAsUser:
+                            description: The UID to run the entrypoint of the container
+                              process. Defaults to user specified in image metadata
+                              if unspecified. May also be set in PodSecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext, the
+                              value specified in SecurityContext takes precedence.
+                            format: int64
+                            type: integer
+                          seLinuxOptions:
+                            description: The SELinux context to be applied to the container.
+                              If unspecified, the container runtime will allocate a
+                              random SELinux context for each container.  May also be
+                              set in PodSecurityContext.  If set in both SecurityContext
+                              and PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            properties:
+                              level:
+                                description: Level is SELinux level label that applies
+                                  to the container.
+                                type: string
+                              role:
+                                description: Role is a SELinux role label that applies
+                                  to the container.
+                                type: string
+                              type:
+                                description: Type is a SELinux type label that applies
+                                  to the container.
+                                type: string
+                              user:
+                                description: User is a SELinux user label that applies
+                                  to the container.
+                                type: string
+                            type: object
+                          windowsOptions:
+                            description: The Windows specific settings applied to all
+                              containers. If unspecified, the options from the PodSecurityContext
+                              will be used. If set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence.
+                            properties:
+                              gmsaCredentialSpec:
+                                description: GMSACredentialSpec is where the GMSA admission
+                                  webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                  inlines the contents of the GMSA credential spec named
+                                  by the GMSACredentialSpecName field.
+                                type: string
+                              gmsaCredentialSpecName:
+                                description: GMSACredentialSpecName is the name of the
+                                  GMSA credential spec to use.
+                                type: string
+                              runAsUserName:
+                                description: The UserName in Windows to run the entrypoint
+                                  of the container process. Defaults to the user specified
+                                  in image metadata if unspecified. May also be set
+                                  in PodSecurityContext. If set in both SecurityContext
+                                  and PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence.
+                                type: string
+                            type: object
+                        type: object
                       exportMetrics:
                         type: boolean
                         description: If this flag is enabled it will expose the storage cluster metrics to Prometheus.
@@ -906,6 +1113,2280 @@ spec:
                             type: boolean
                             description: Flag indicating whether AlertManager needs to be enabled and deployed
                               by the Storage operator.
+                      replicas:
+                        description: Total number of non-terminated pods targeted by this
+                          Prometheus deployment (their labels match the selector).
+                        format: int32
+                        type: integer
+                      retention:
+                        description: Time duration Prometheus shall retain data for. Default
+                          is '24h' if retentionSize is not set, and must match the regular
+                          expression `[0-9]+(ms|s|m|h|d|w|y)` (milliseconds seconds minutes
+                          hours days weeks years).
+                        pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                        type: string
+                      retentionSize:
+                        description: Maximum amount of disk space used by blocks.
+                        pattern: (^0|([0-9]*[.])?[0-9]+((K|M|G|T|E|P)i?)?B)$
+                        type: string
+                      storage:
+                        description: Storage spec to specify how storage shall be used.
+                        properties:
+                          disableMountSubPath:
+                            description: 'Deprecated: subPath usage will be disabled by default
+                                            in a future release, this option will become unnecessary. DisableMountSubPath
+                                            allows to remove any subPath usage in volume mounts.'
+                            type: boolean
+                          emptyDir:
+                            description: 'EmptyDirVolumeSource to be used by the StatefulSet.
+                                            If specified, used in place of any volumeClaimTemplate. More
+                                            info: https://kubernetes.io/docs/concepts/storage/volumes/#emptydir'
+                            properties:
+                              medium:
+                                description: 'medium represents what type of storage medium
+                                                should back this directory. The default is "" which means
+                                                to use the node''s default medium. Must be an empty string
+                                                (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                type: string
+                              sizeLimit:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                description: 'sizeLimit is the total amount of local storage
+                                                required for this EmptyDir volume. The size limit is also
+                                                applicable for memory medium. The maximum usage on memory
+                                                medium EmptyDir would be the minimum value between the SizeLimit
+                                                specified here and the sum of memory limits of all containers
+                                                in a pod. The default is nil which means that the limit
+                                                is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          ephemeral:
+                            description: 'EphemeralVolumeSource to be used by the StatefulSet.
+                                            This is a beta field in k8s 1.21, for lower versions, starting
+                                            with k8s 1.19, it requires enabling the GenericEphemeralVolume
+                                            feature gate. More info: https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/#generic-ephemeral-volumes'
+                            properties:
+                              volumeClaimTemplate:
+                                description: "Will be used to create a stand-alone PVC to
+                                                provision the volume. The pod in which this EphemeralVolumeSource
+                                                is embedded will be the owner of the PVC, i.e. the PVC will
+                                                be deleted together with the pod.  The name of the PVC will
+                                                be `<pod name>-<volume name>` where `<volume name>` is the
+                                                name from the `PodSpec.Volumes` array entry. Pod validation
+                                                will reject the pod if the concatenated name is not valid
+                                                for a PVC (for example, too long). \n An existing PVC with
+                                                that name that is not owned by the pod will *not* be used
+                                                for the pod to avoid using an unrelated volume by mistake.
+                                                Starting the pod is then blocked until the unrelated PVC
+                                                is removed. If such a pre-created PVC is meant to be used
+                                                by the pod, the PVC has to updated with an owner reference
+                                                to the pod once the pod exists. Normally this should not
+                                                be necessary, but it may be useful when manually reconstructing
+                                                a broken cluster. \n This field is read-only and no changes
+                                                will be made by Kubernetes to the PVC after it has been
+                                                created. \n Required, must not be nil."
+                                properties:
+                                  metadata:
+                                    description: May contain labels and annotations that will
+                                      be copied into the PVC when creating it. No other fields
+                                      are allowed and will be rejected during validation.
+                                    type: object
+                                  spec:
+                                    description: The specification for the PersistentVolumeClaim.
+                                      The entire content is copied unchanged into the PVC
+                                      that gets created from this template. The same fields
+                                      as in a PersistentVolumeClaim are also valid here.
+                                    properties:
+                                      accessModes:
+                                        description: 'accessModes contains the desired access
+                                                        modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                        items:
+                                          type: string
+                                        type: array
+                                      dataSource:
+                                        description: 'dataSource field can be used to specify
+                                                        either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                                        * An existing PVC (PersistentVolumeClaim) If the
+                                                        provisioner or an external controller can support
+                                                        the specified data source, it will create a new
+                                                        volume based on the contents of the specified data
+                                                        source. When the AnyVolumeDataSource feature gate
+                                                        is enabled, dataSource contents will be copied to
+                                                        dataSourceRef, and dataSourceRef contents will be
+                                                        copied to dataSource when dataSourceRef.namespace
+                                                        is not specified. If the namespace is specified,
+                                                        then dataSourceRef will not be copied to dataSource.'
+                                        properties:
+                                          apiGroup:
+                                            description: APIGroup is the group for the resource
+                                              being referenced. If APIGroup is not specified,
+                                              the specified Kind must be in the core API group.
+                                              For any other third-party types, APIGroup is
+                                              required.
+                                            type: string
+                                          kind:
+                                            description: Kind is the type of resource being
+                                              referenced
+                                            type: string
+                                          name:
+                                            description: Name is the name of resource being
+                                              referenced
+                                            type: string
+                                        required:
+                                          - kind
+                                          - name
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      dataSourceRef:
+                                        description: 'dataSourceRef specifies the object from
+                                                        which to populate the volume with data, if a non-empty
+                                                        volume is desired. This may be any object from a
+                                                        non-empty API group (non core object) or a PersistentVolumeClaim
+                                                        object. When this field is specified, volume binding
+                                                        will only succeed if the type of the specified object
+                                                        matches some installed volume populator or dynamic
+                                                        provisioner. This field will replace the functionality
+                                                        of the dataSource field and as such if both fields
+                                                        are non-empty, they must have the same value. For
+                                                        backwards compatibility, when namespace isn''t specified
+                                                        in dataSourceRef, both fields (dataSource and dataSourceRef)
+                                                        will be set to the same value automatically if one
+                                                        of them is empty and the other is non-empty. When
+                                                        namespace is specified in dataSourceRef, dataSource
+                                                        isn''t set to the same value and must be empty.
+                                                        There are three important differences between dataSource
+                                                        and dataSourceRef: * While dataSource only allows
+                                                        two specific types of objects, dataSourceRef allows
+                                                        any non-core object, as well as PersistentVolumeClaim
+                                                        objects. * While dataSource ignores disallowed values
+                                                        (dropping them), dataSourceRef preserves all values,
+                                                        and generates an error if a disallowed value is
+                                                        specified. * While dataSource only allows local
+                                                        objects, dataSourceRef allows objects in any namespaces.
+                                                        (Beta) Using this field requires the AnyVolumeDataSource
+                                                        feature gate to be enabled. (Alpha) Using the namespace
+                                                        field of dataSourceRef requires the CrossNamespaceVolumeDataSource
+                                                        feature gate to be enabled.'
+                                        properties:
+                                          apiGroup:
+                                            description: APIGroup is the group for the resource
+                                              being referenced. If APIGroup is not specified,
+                                              the specified Kind must be in the core API group.
+                                              For any other third-party types, APIGroup is
+                                              required.
+                                            type: string
+                                          kind:
+                                            description: Kind is the type of resource being
+                                              referenced
+                                            type: string
+                                          name:
+                                            description: Name is the name of resource being
+                                              referenced
+                                            type: string
+                                          namespace:
+                                            description: Namespace is the namespace of resource
+                                              being referenced Note that when a namespace
+                                              is specified, a gateway.networking.k8s.io/ReferenceGrant
+                                              object is required in the referent namespace
+                                              to allow that namespace's owner to accept the
+                                              reference. See the ReferenceGrant documentation
+                                              for details. (Alpha) This field requires the
+                                              CrossNamespaceVolumeDataSource feature gate
+                                              to be enabled.
+                                            type: string
+                                        required:
+                                          - kind
+                                          - name
+                                        type: object
+                                      resources:
+                                        description: 'resources represents the minimum resources
+                                                        the volume should have. If RecoverVolumeExpansionFailure
+                                                        feature is enabled users are allowed to specify
+                                                        resource requirements that are lower than previous
+                                                        value but must still be higher than capacity recorded
+                                                        in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                        properties:
+                                          claims:
+                                            description: "Claims lists the names of resources,
+                                                            defined in spec.resourceClaims, that are used
+                                                            by this container. \n This is an alpha field
+                                                            and requires enabling the DynamicResourceAllocation
+                                                            feature gate. \n This field is immutable."
+                                            items:
+                                              description: ResourceClaim references one entry
+                                                in PodSpec.ResourceClaims.
+                                              properties:
+                                                name:
+                                                  description: Name must match the name of
+                                                    one entry in pod.spec.resourceClaims of
+                                                    the Pod where this field is used. It makes
+                                                    that resource available inside a container.
+                                                  type: string
+                                              required:
+                                                - name
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-map-keys:
+                                              - name
+                                            x-kubernetes-list-type: map
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: 'Limits describes the maximum amount
+                                                            of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: 'Requests describes the minimum amount
+                                                            of compute resources required. If Requests is
+                                                            omitted for a container, it defaults to Limits
+                                                            if that is explicitly specified, otherwise to
+                                                            an implementation-defined value. More info:
+                                                            https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                            type: object
+                                        type: object
+                                      selector:
+                                        description: selector is a label query over volumes
+                                          to consider for binding.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list of label
+                                              selector requirements. The requirements are
+                                              ANDed.
+                                            items:
+                                              description: A label selector requirement is
+                                                a selector that contains values, a key, and
+                                                an operator that relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key that the
+                                                    selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents a key's
+                                                    relationship to a set of values. Valid
+                                                    operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array of string
+                                                    values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If
+                                                    the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array
+                                                    is replaced during a strategic merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator is "In",
+                                              and the values array contains only "value".
+                                              The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      storageClassName:
+                                        description: 'storageClassName is the name of the
+                                                        StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                        type: string
+                                      volumeMode:
+                                        description: volumeMode defines what type of volume
+                                          is required by the claim. Value of Filesystem is
+                                          implied when not included in claim spec.
+                                        type: string
+                                      volumeName:
+                                        description: volumeName is the binding reference to
+                                          the PersistentVolume backing this claim.
+                                        type: string
+                                    type: object
+                                required:
+                                  - spec
+                                type: object
+                            type: object
+                          volumeClaimTemplate:
+                            description: A PVC spec to be used by the StatefulSet. The easiest
+                              way to use a volume that cannot be automatically provisioned
+                              (for whatever reason) is to use a label selector alongside manually
+                              created PersistentVolumes.
+                            properties:
+                              apiVersion:
+                                description: 'APIVersion defines the versioned schema of this
+                                                representation of an object. Servers should convert recognized
+                                                schemas to the latest internal value, and may reject unrecognized
+                                                values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                                type: string
+                              kind:
+                                description: 'Kind is a string value representing the REST
+                                                resource this object represents. Servers may infer this
+                                                from the endpoint the client submits requests to. Cannot
+                                                be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              metadata:
+                                description: EmbeddedMetadata contains metadata relevant to
+                                  an EmbeddedResource.
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: 'Annotations is an unstructured key value
+                                                    map stored with a resource that may be set by external
+                                                    tools to store and retrieve arbitrary metadata. They
+                                                    are not queryable and should be preserved when modifying
+                                                    objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    description: 'Map of string keys and values that can be
+                                                    used to organize and categorize (scope and select) objects.
+                                                    May match selectors of replication controllers and services.
+                                                    More info: http://kubernetes.io/docs/user-guide/labels'
+                                    type: object
+                                  name:
+                                    description: 'Name must be unique within a namespace.
+                                                    Is required when creating resources, although some resources
+                                                    may allow a client to request the generation of an appropriate
+                                                    name automatically. Name is primarily intended for creation
+                                                    idempotence and configuration definition. Cannot be
+                                                    updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                                    type: string
+                                type: object
+                              spec:
+                                description: 'Spec defines the desired characteristics of
+                                                a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                properties:
+                                  accessModes:
+                                    description: 'accessModes contains the desired access
+                                                    modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                    items:
+                                      type: string
+                                    type: array
+                                  dataSource:
+                                    description: 'dataSource field can be used to specify
+                                                    either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                                    * An existing PVC (PersistentVolumeClaim) If the provisioner
+                                                    or an external controller can support the specified
+                                                    data source, it will create a new volume based on the
+                                                    contents of the specified data source. When the AnyVolumeDataSource
+                                                    feature gate is enabled, dataSource contents will be
+                                                    copied to dataSourceRef, and dataSourceRef contents
+                                                    will be copied to dataSource when dataSourceRef.namespace
+                                                    is not specified. If the namespace is specified, then
+                                                    dataSourceRef will not be copied to dataSource.'
+                                    properties:
+                                      apiGroup:
+                                        description: APIGroup is the group for the resource
+                                          being referenced. If APIGroup is not specified,
+                                          the specified Kind must be in the core API group.
+                                          For any other third-party types, APIGroup is required.
+                                        type: string
+                                      kind:
+                                        description: Kind is the type of resource being referenced
+                                        type: string
+                                      name:
+                                        description: Name is the name of resource being referenced
+                                        type: string
+                                    required:
+                                      - kind
+                                      - name
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  dataSourceRef:
+                                    description: 'dataSourceRef specifies the object from
+                                                    which to populate the volume with data, if a non-empty
+                                                    volume is desired. This may be any object from a non-empty
+                                                    API group (non core object) or a PersistentVolumeClaim
+                                                    object. When this field is specified, volume binding
+                                                    will only succeed if the type of the specified object
+                                                    matches some installed volume populator or dynamic provisioner.
+                                                    This field will replace the functionality of the dataSource
+                                                    field and as such if both fields are non-empty, they
+                                                    must have the same value. For backwards compatibility,
+                                                    when namespace isn''t specified in dataSourceRef, both
+                                                    fields (dataSource and dataSourceRef) will be set to
+                                                    the same value automatically if one of them is empty
+                                                    and the other is non-empty. When namespace is specified
+                                                    in dataSourceRef, dataSource isn''t set to the same
+                                                    value and must be empty. There are three important differences
+                                                    between dataSource and dataSourceRef: * While dataSource
+                                                    only allows two specific types of objects, dataSourceRef
+                                                    allows any non-core object, as well as PersistentVolumeClaim
+                                                    objects. * While dataSource ignores disallowed values
+                                                    (dropping them), dataSourceRef preserves all values,
+                                                    and generates an error if a disallowed value is specified.
+                                                    * While dataSource only allows local objects, dataSourceRef
+                                                    allows objects in any namespaces. (Beta) Using this
+                                                    field requires the AnyVolumeDataSource feature gate
+                                                    to be enabled. (Alpha) Using the namespace field of
+                                                    dataSourceRef requires the CrossNamespaceVolumeDataSource
+                                                    feature gate to be enabled.'
+                                    properties:
+                                      apiGroup:
+                                        description: APIGroup is the group for the resource
+                                          being referenced. If APIGroup is not specified,
+                                          the specified Kind must be in the core API group.
+                                          For any other third-party types, APIGroup is required.
+                                        type: string
+                                      kind:
+                                        description: Kind is the type of resource being referenced
+                                        type: string
+                                      name:
+                                        description: Name is the name of resource being referenced
+                                        type: string
+                                      namespace:
+                                        description: Namespace is the namespace of resource
+                                          being referenced Note that when a namespace is specified,
+                                          a gateway.networking.k8s.io/ReferenceGrant object
+                                          is required in the referent namespace to allow that
+                                          namespace's owner to accept the reference. See the
+                                          ReferenceGrant documentation for details. (Alpha)
+                                          This field requires the CrossNamespaceVolumeDataSource
+                                          feature gate to be enabled.
+                                        type: string
+                                    required:
+                                      - kind
+                                      - name
+                                    type: object
+                                  resources:
+                                    description: 'resources represents the minimum resources
+                                                    the volume should have. If RecoverVolumeExpansionFailure
+                                                    feature is enabled users are allowed to specify resource
+                                                    requirements that are lower than previous value but
+                                                    must still be higher than capacity recorded in the status
+                                                    field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                    properties:
+                                      claims:
+                                        description: "Claims lists the names of resources,
+                                                        defined in spec.resourceClaims, that are used by
+                                                        this container. \n This is an alpha field and requires
+                                                        enabling the DynamicResourceAllocation feature gate.
+                                                        \n This field is immutable."
+                                        items:
+                                          description: ResourceClaim references one entry
+                                            in PodSpec.ResourceClaims.
+                                          properties:
+                                            name:
+                                              description: Name must match the name of one
+                                                entry in pod.spec.resourceClaims of the Pod
+                                                where this field is used. It makes that resource
+                                                available inside a container.
+                                              type: string
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: 'Limits describes the maximum amount
+                                                        of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: 'Requests describes the minimum amount
+                                                        of compute resources required. If Requests is omitted
+                                                        for a container, it defaults to Limits if that is
+                                                        explicitly specified, otherwise to an implementation-defined
+                                                        value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        type: object
+                                    type: object
+                                  selector:
+                                    description: selector is a label query over volumes to
+                                      consider for binding.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label selector
+                                          requirements. The requirements are ANDed.
+                                        items:
+                                          description: A label selector requirement is a selector
+                                            that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that the selector
+                                                applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's relationship
+                                                to a set of values. Valid operators are In,
+                                                NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string values.
+                                                If the operator is In or NotIn, the values
+                                                array must be non-empty. If the operator is
+                                                Exists or DoesNotExist, the values array must
+                                                be empty. This array is replaced during a
+                                                strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value} pairs.
+                                          A single {key,value} in the matchLabels map is equivalent
+                                          to an element of matchExpressions, whose key field
+                                          is "key", the operator is "In", and the values array
+                                          contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  storageClassName:
+                                    description: 'storageClassName is the name of the StorageClass
+                                                    required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                    type: string
+                                  volumeMode:
+                                    description: volumeMode defines what type of volume is
+                                      required by the claim. Value of Filesystem is implied
+                                      when not included in claim spec.
+                                    type: string
+                                  volumeName:
+                                    description: volumeName is the binding reference to the
+                                      PersistentVolume backing this claim.
+                                    type: string
+                                type: object
+                              status:
+                                description: 'Status represents the current information/status
+                                                of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                properties:
+                                  accessModes:
+                                    description: 'accessModes contains the actual access modes
+                                                    the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                    items:
+                                      type: string
+                                    type: array
+                                  allocatedResources:
+                                    additionalProperties:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: allocatedResources is the storage resource
+                                      within AllocatedResources tracks the capacity allocated
+                                      to a PVC. It may be larger than the actual capacity
+                                      when a volume expansion operation is requested. For
+                                      storage quota, the larger value from allocatedResources
+                                      and PVC.spec.resources is used. If allocatedResources
+                                      is not set, PVC.spec.resources alone is used for quota
+                                      calculation. If a volume expansion capacity request
+                                      is lowered, allocatedResources is only lowered if there
+                                      are no expansion operations in progress and if the actual
+                                      volume capacity is equal or lower than the requested
+                                      capacity. This is an alpha field and requires enabling
+                                      RecoverVolumeExpansionFailure feature.
+                                    type: object
+                                  capacity:
+                                    additionalProperties:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: capacity represents the actual resources
+                                      of the underlying volume.
+                                    type: object
+                                  conditions:
+                                    description: conditions is the current Condition of persistent
+                                      volume claim. If underlying persistent volume is being
+                                      resized then the Condition will be set to 'ResizeStarted'.
+                                    items:
+                                      description: PersistentVolumeClaimCondition contails
+                                        details about state of pvc
+                                      properties:
+                                        lastProbeTime:
+                                          description: lastProbeTime is the time we probed
+                                            the condition.
+                                          format: date-time
+                                          type: string
+                                        lastTransitionTime:
+                                          description: lastTransitionTime is the time the
+                                            condition transitioned from one status to another.
+                                          format: date-time
+                                          type: string
+                                        message:
+                                          description: message is the human-readable message
+                                            indicating details about last transition.
+                                          type: string
+                                        reason:
+                                          description: reason is a unique, this should be
+                                            a short, machine understandable string that gives
+                                            the reason for condition's last transition. If
+                                            it reports "ResizeStarted" that means the underlying
+                                            persistent volume is being resized.
+                                          type: string
+                                        status:
+                                          type: string
+                                        type:
+                                          description: PersistentVolumeClaimConditionType
+                                            is a valid value of PersistentVolumeClaimCondition.Type
+                                          type: string
+                                      required:
+                                        - status
+                                        - type
+                                      type: object
+                                    type: array
+                                  phase:
+                                    description: phase represents the current phase of PersistentVolumeClaim.
+                                    type: string
+                                  resizeStatus:
+                                    description: resizeStatus stores status of resize operation.
+                                      ResizeStatus is not set by default but when expansion
+                                      is complete resizeStatus is set to empty string by resize
+                                      controller or kubelet. This is an alpha field and requires
+                                      enabling RecoverVolumeExpansionFailure feature.
+                                    type: string
+                                type: object
+                            type: object
+                        type: object
+                      volumes:
+                        description: Volumes allows configuration of additional volumes on
+                          the output StatefulSet definition. Volumes specified will be appended
+                          to other volumes that are generated as a result of StorageSpec objects.
+                        items:
+                          description: Volume represents a named volume in a pod that may
+                            be accessed by any container in the pod.
+                          properties:
+                            awsElasticBlockStore:
+                              description: 'awsElasticBlockStore represents an AWS Disk resource
+                              that is attached to a kubelet''s host machine and then exposed
+                              to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              properties:
+                                fsType:
+                                  description: 'fsType is the filesystem type of the volume
+                                  that you want to mount. Tip: Ensure that the filesystem
+                                  type is supported by the host operating system. Examples:
+                                  "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                                  if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                  TODO: how do we prevent errors in the filesystem from
+                                  compromising the machine'
+                                  type: string
+                                partition:
+                                  description: 'partition is the partition in the volume that
+                                  you want to mount. If omitted, the default is to mount
+                                  by volume name. Examples: For volume /dev/sda1, you specify
+                                  the partition as "1". Similarly, the volume partition
+                                  for /dev/sda is "0" (or you can leave the property empty).'
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  description: 'readOnly value true will force the readOnly
+                                  setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  type: boolean
+                                volumeID:
+                                  description: 'volumeID is unique ID of the persistent disk
+                                  resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  type: string
+                              required:
+                                - volumeID
+                              type: object
+                            azureDisk:
+                              description: azureDisk represents an Azure Data Disk mount on
+                                the host and bind mount to the pod.
+                              properties:
+                                cachingMode:
+                                  description: 'cachingMode is the Host Caching mode: None,
+                                  Read Only, Read Write.'
+                                  type: string
+                                diskName:
+                                  description: diskName is the Name of the data disk in the
+                                    blob storage
+                                  type: string
+                                diskURI:
+                                  description: diskURI is the URI of data disk in the blob
+                                    storage
+                                  type: string
+                                fsType:
+                                  description: fsType is Filesystem type to mount. Must be
+                                    a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                                    if unspecified.
+                                  type: string
+                                kind:
+                                  description: 'kind expected values are Shared: multiple
+                                  blob disks per storage account  Dedicated: single blob
+                                  disk per storage account  Managed: azure managed data
+                                  disk (only in managed availability set). defaults to shared'
+                                  type: string
+                                readOnly:
+                                  description: readOnly Defaults to false (read/write). ReadOnly
+                                    here will force the ReadOnly setting in VolumeMounts.
+                                  type: boolean
+                              required:
+                                - diskName
+                                - diskURI
+                              type: object
+                            azureFile:
+                              description: azureFile represents an Azure File Service mount
+                                on the host and bind mount to the pod.
+                              properties:
+                                readOnly:
+                                  description: readOnly defaults to false (read/write). ReadOnly
+                                    here will force the ReadOnly setting in VolumeMounts.
+                                  type: boolean
+                                secretName:
+                                  description: secretName is the  name of secret that contains
+                                    Azure Storage Account Name and Key
+                                  type: string
+                                shareName:
+                                  description: shareName is the azure share Name
+                                  type: string
+                              required:
+                                - secretName
+                                - shareName
+                              type: object
+                            cephfs:
+                              description: cephFS represents a Ceph FS mount on the host that
+                                shares a pod's lifetime
+                              properties:
+                                monitors:
+                                  description: 'monitors is Required: Monitors is a collection
+                                  of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  items:
+                                    type: string
+                                  type: array
+                                path:
+                                  description: 'path is Optional: Used as the mounted root,
+                                  rather than the full Ceph tree, default is /'
+                                  type: string
+                                readOnly:
+                                  description: 'readOnly is Optional: Defaults to false (read/write).
+                                  ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                  More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  type: boolean
+                                secretFile:
+                                  description: 'secretFile is Optional: SecretFile is the
+                                  path to key ring for User, default is /etc/ceph/user.secret
+                                  More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  type: string
+                                secretRef:
+                                  description: 'secretRef is Optional: SecretRef is reference
+                                  to the authentication secret for User, default is empty.
+                                  More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                user:
+                                  description: 'user is optional: User is the rados user name,
+                                  default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  type: string
+                              required:
+                                - monitors
+                              type: object
+                            cinder:
+                              description: 'cinder represents a cinder volume attached and
+                              mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              properties:
+                                fsType:
+                                  description: 'fsType is the filesystem type to mount. Must
+                                  be a filesystem type supported by the host operating system.
+                                  Examples: "ext4", "xfs", "ntfs". Implicitly inferred to
+                                  be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  type: string
+                                readOnly:
+                                  description: 'readOnly defaults to false (read/write). ReadOnly
+                                  here will force the ReadOnly setting in VolumeMounts.
+                                  More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  type: boolean
+                                secretRef:
+                                  description: 'secretRef is optional: points to a secret
+                                  object containing parameters used to connect to OpenStack.'
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                volumeID:
+                                  description: 'volumeID used to identify the volume in cinder.
+                                  More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  type: string
+                              required:
+                                - volumeID
+                              type: object
+                            configMap:
+                              description: configMap represents a configMap that should populate
+                                this volume
+                              properties:
+                                defaultMode:
+                                  description: 'defaultMode is optional: mode bits used to
+                                  set permissions on created files by default. Must be an
+                                  octal value between 0000 and 0777 or a decimal value between
+                                  0 and 511. YAML accepts both octal and decimal values,
+                                  JSON requires decimal values for mode bits. Defaults to
+                                  0644. Directories within the path are not affected by
+                                  this setting. This might be in conflict with other options
+                                  that affect the file mode, like fsGroup, and the result
+                                  can be other mode bits set.'
+                                  format: int32
+                                  type: integer
+                                items:
+                                  description: items if unspecified, each key-value pair in
+                                    the Data field of the referenced ConfigMap will be projected
+                                    into the volume as a file whose name is the key and content
+                                    is the value. If specified, the listed keys will be projected
+                                    into the specified paths, and unlisted keys will not be
+                                    present. If a key is specified which is not present in
+                                    the ConfigMap, the volume setup will error unless it is
+                                    marked optional. Paths must be relative and may not contain
+                                    the '..' path or start with '..'.
+                                  items:
+                                    description: Maps a string key to a path within a volume.
+                                    properties:
+                                      key:
+                                        description: key is the key to project.
+                                        type: string
+                                      mode:
+                                        description: 'mode is Optional: mode bits used to
+                                        set permissions on this file. Must be an octal value
+                                        between 0000 and 0777 or a decimal value between
+                                        0 and 511. YAML accepts both octal and decimal values,
+                                        JSON requires decimal values for mode bits. If not
+                                        specified, the volume defaultMode will be used.
+                                        This might be in conflict with other options that
+                                        affect the file mode, like fsGroup, and the result
+                                        can be other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: path is the relative path of the file
+                                          to map the key to. May not be an absolute path.
+                                          May not contain the path element '..'. May not start
+                                          with the string '..'.
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  type: string
+                                optional:
+                                  description: optional specify whether the ConfigMap or its
+                                    keys must be defined
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            csi:
+                              description: csi (Container Storage Interface) represents ephemeral
+                                storage that is handled by certain external CSI drivers (Beta
+                                feature).
+                              properties:
+                                driver:
+                                  description: driver is the name of the CSI driver that handles
+                                    this volume. Consult with your admin for the correct name
+                                    as registered in the cluster.
+                                  type: string
+                                fsType:
+                                  description: fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                    If not provided, the empty value is passed to the associated
+                                    CSI driver which will determine the default filesystem
+                                    to apply.
+                                  type: string
+                                nodePublishSecretRef:
+                                  description: nodePublishSecretRef is a reference to the
+                                    secret object containing sensitive information to pass
+                                    to the CSI driver to complete the CSI NodePublishVolume
+                                    and NodeUnpublishVolume calls. This field is optional,
+                                    and  may be empty if no secret is required. If the secret
+                                    object contains more than one secret, all secret references
+                                    are passed.
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                readOnly:
+                                  description: readOnly specifies a read-only configuration
+                                    for the volume. Defaults to false (read/write).
+                                  type: boolean
+                                volumeAttributes:
+                                  additionalProperties:
+                                    type: string
+                                  description: volumeAttributes stores driver-specific properties
+                                    that are passed to the CSI driver. Consult your driver's
+                                    documentation for supported values.
+                                  type: object
+                              required:
+                                - driver
+                              type: object
+                            downwardAPI:
+                              description: downwardAPI represents downward API about the pod
+                                that should populate this volume
+                              properties:
+                                defaultMode:
+                                  description: 'Optional: mode bits to use on created files
+                                  by default. Must be a Optional: mode bits used to set
+                                  permissions on created files by default. Must be an octal
+                                  value between 0000 and 0777 or a decimal value between
+                                  0 and 511. YAML accepts both octal and decimal values,
+                                  JSON requires decimal values for mode bits. Defaults to
+                                  0644. Directories within the path are not affected by
+                                  this setting. This might be in conflict with other options
+                                  that affect the file mode, like fsGroup, and the result
+                                  can be other mode bits set.'
+                                  format: int32
+                                  type: integer
+                                items:
+                                  description: Items is a list of downward API volume file
+                                  items:
+                                    description: DownwardAPIVolumeFile represents information
+                                      to create the file containing the pod field
+                                    properties:
+                                      fieldRef:
+                                        description: 'Required: Selects a field of the pod:
+                                        only annotations, labels, name and namespace are
+                                        supported.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the FieldPath
+                                              is written in terms of, defaults to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select in the
+                                              specified API version.
+                                            type: string
+                                        required:
+                                          - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      mode:
+                                        description: 'Optional: mode bits used to set permissions
+                                        on this file, must be an octal value between 0000
+                                        and 0777 or a decimal value between 0 and 511. YAML
+                                        accepts both octal and decimal values, JSON requires
+                                        decimal values for mode bits. If not specified,
+                                        the volume defaultMode will be used. This might
+                                        be in conflict with other options that affect the
+                                        file mode, like fsGroup, and the result can be other
+                                        mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: 'Required: Path is  the relative path
+                                        name of the file to be created. Must not be absolute
+                                        or contain the ''..'' path. Must be utf-8 encoded.
+                                        The first item of the relative path must not start
+                                        with ''..'''
+                                        type: string
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, requests.cpu and requests.memory)
+                                        are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required for volumes,
+                                            optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            description: Specifies the output format of the
+                                              exposed resources, defaults to "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                          - resource
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    required:
+                                      - path
+                                    type: object
+                                  type: array
+                              type: object
+                            emptyDir:
+                              description: 'emptyDir represents a temporary directory that
+                              shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                              properties:
+                                medium:
+                                  description: 'medium represents what type of storage medium
+                                  should back this directory. The default is "" which means
+                                  to use the node''s default medium. Must be an empty string
+                                  (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                  type: string
+                                sizeLimit:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: 'sizeLimit is the total amount of local storage
+                                  required for this EmptyDir volume. The size limit is also
+                                  applicable for memory medium. The maximum usage on memory
+                                  medium EmptyDir would be the minimum value between the
+                                  SizeLimit specified here and the sum of memory limits
+                                  of all containers in a pod. The default is nil which means
+                                  that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            ephemeral:
+                              description: "ephemeral represents a volume that is handled
+                              by a cluster storage driver. The volume's lifecycle is tied
+                              to the pod that defines it - it will be created before the
+                              pod starts, and deleted when the pod is removed. \n Use this
+                              if: a) the volume is only needed while the pod runs, b) features
+                              of normal volumes like restoring from snapshot or capacity
+                              tracking are needed, c) the storage driver is specified through
+                              a storage class, and d) the storage driver supports dynamic
+                              volume provisioning through a PersistentVolumeClaim (see EphemeralVolumeSource
+                              for more information on the connection between this volume
+                              type and PersistentVolumeClaim). \n Use PersistentVolumeClaim
+                              or one of the vendor-specific APIs for volumes that persist
+                              for longer than the lifecycle of an individual pod. \n Use
+                              CSI for light-weight local ephemeral volumes if the CSI driver
+                              is meant to be used that way - see the documentation of the
+                              driver for more information. \n A pod can use both types of
+                              ephemeral volumes and persistent volumes at the same time."
+                              properties:
+                                volumeClaimTemplate:
+                                  description: "Will be used to create a stand-alone PVC to
+                                  provision the volume. The pod in which this EphemeralVolumeSource
+                                  is embedded will be the owner of the PVC, i.e. the PVC
+                                  will be deleted together with the pod.  The name of the
+                                  PVC will be `<pod name>-<volume name>` where `<volume
+                                  name>` is the name from the `PodSpec.Volumes` array entry.
+                                  Pod validation will reject the pod if the concatenated
+                                  name is not valid for a PVC (for example, too long). \n
+                                  An existing PVC with that name that is not owned by the
+                                  pod will *not* be used for the pod to avoid using an unrelated
+                                  volume by mistake. Starting the pod is then blocked until
+                                  the unrelated PVC is removed. If such a pre-created PVC
+                                  is meant to be used by the pod, the PVC has to updated
+                                  with an owner reference to the pod once the pod exists.
+                                  Normally this should not be necessary, but it may be useful
+                                  when manually reconstructing a broken cluster. \n This
+                                  field is read-only and no changes will be made by Kubernetes
+                                  to the PVC after it has been created. \n Required, must
+                                  not be nil."
+                                  properties:
+                                    metadata:
+                                      description: May contain labels and annotations that
+                                        will be copied into the PVC when creating it. No other
+                                        fields are allowed and will be rejected during validation.
+                                      type: object
+                                    spec:
+                                      description: The specification for the PersistentVolumeClaim.
+                                        The entire content is copied unchanged into the PVC
+                                        that gets created from this template. The same fields
+                                        as in a PersistentVolumeClaim are also valid here.
+                                      properties:
+                                        accessModes:
+                                          description: 'accessModes contains the desired access
+                                          modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                          items:
+                                            type: string
+                                          type: array
+                                        dataSource:
+                                          description: 'dataSource field can be used to specify
+                                          either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                          * An existing PVC (PersistentVolumeClaim) If the
+                                          provisioner or an external controller can support
+                                          the specified data source, it will create a new
+                                          volume based on the contents of the specified
+                                          data source. When the AnyVolumeDataSource feature
+                                          gate is enabled, dataSource contents will be copied
+                                          to dataSourceRef, and dataSourceRef contents will
+                                          be copied to dataSource when dataSourceRef.namespace
+                                          is not specified. If the namespace is specified,
+                                          then dataSourceRef will not be copied to dataSource.'
+                                          properties:
+                                            apiGroup:
+                                              description: APIGroup is the group for the resource
+                                                being referenced. If APIGroup is not specified,
+                                                the specified Kind must be in the core API
+                                                group. For any other third-party types, APIGroup
+                                                is required.
+                                              type: string
+                                            kind:
+                                              description: Kind is the type of resource being
+                                                referenced
+                                              type: string
+                                            name:
+                                              description: Name is the name of resource being
+                                                referenced
+                                              type: string
+                                          required:
+                                            - kind
+                                            - name
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        dataSourceRef:
+                                          description: 'dataSourceRef specifies the object
+                                          from which to populate the volume with data, if
+                                          a non-empty volume is desired. This may be any
+                                          object from a non-empty API group (non core object)
+                                          or a PersistentVolumeClaim object. When this field
+                                          is specified, volume binding will only succeed
+                                          if the type of the specified object matches some
+                                          installed volume populator or dynamic provisioner.
+                                          This field will replace the functionality of the
+                                          dataSource field and as such if both fields are
+                                          non-empty, they must have the same value. For
+                                          backwards compatibility, when namespace isn''t
+                                          specified in dataSourceRef, both fields (dataSource
+                                          and dataSourceRef) will be set to the same value
+                                          automatically if one of them is empty and the
+                                          other is non-empty. When namespace is specified
+                                          in dataSourceRef, dataSource isn''t set to the
+                                          same value and must be empty. There are three
+                                          important differences between dataSource and dataSourceRef:
+                                          * While dataSource only allows two specific types
+                                          of objects, dataSourceRef allows any non-core
+                                          object, as well as PersistentVolumeClaim objects.
+                                          * While dataSource ignores disallowed values (dropping
+                                          them), dataSourceRef preserves all values, and
+                                          generates an error if a disallowed value is specified.
+                                          * While dataSource only allows local objects,
+                                          dataSourceRef allows objects in any namespaces.
+                                          (Beta) Using this field requires the AnyVolumeDataSource
+                                          feature gate to be enabled. (Alpha) Using the
+                                          namespace field of dataSourceRef requires the
+                                          CrossNamespaceVolumeDataSource feature gate to
+                                          be enabled.'
+                                          properties:
+                                            apiGroup:
+                                              description: APIGroup is the group for the resource
+                                                being referenced. If APIGroup is not specified,
+                                                the specified Kind must be in the core API
+                                                group. For any other third-party types, APIGroup
+                                                is required.
+                                              type: string
+                                            kind:
+                                              description: Kind is the type of resource being
+                                                referenced
+                                              type: string
+                                            name:
+                                              description: Name is the name of resource being
+                                                referenced
+                                              type: string
+                                            namespace:
+                                              description: Namespace is the namespace of resource
+                                                being referenced Note that when a namespace
+                                                is specified, a gateway.networking.k8s.io/ReferenceGrant
+                                                object is required in the referent namespace
+                                                to allow that namespace's owner to accept
+                                                the reference. See the ReferenceGrant documentation
+                                                for details. (Alpha) This field requires the
+                                                CrossNamespaceVolumeDataSource feature gate
+                                                to be enabled.
+                                              type: string
+                                          required:
+                                            - kind
+                                            - name
+                                          type: object
+                                        resources:
+                                          description: 'resources represents the minimum resources
+                                          the volume should have. If RecoverVolumeExpansionFailure
+                                          feature is enabled users are allowed to specify
+                                          resource requirements that are lower than previous
+                                          value but must still be higher than capacity recorded
+                                          in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                          properties:
+                                            claims:
+                                              description: "Claims lists the names of resources,
+                                              defined in spec.resourceClaims, that are used
+                                              by this container. \n This is an alpha field
+                                              and requires enabling the DynamicResourceAllocation
+                                              feature gate. \n This field is immutable."
+                                              items:
+                                                description: ResourceClaim references one
+                                                  entry in PodSpec.ResourceClaims.
+                                                properties:
+                                                  name:
+                                                    description: Name must match the name
+                                                      of one entry in pod.spec.resourceClaims
+                                                      of the Pod where this field is used.
+                                                      It makes that resource available inside
+                                                      a container.
+                                                    type: string
+                                                required:
+                                                  - name
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-map-keys:
+                                                - name
+                                              x-kubernetes-list-type: map
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              description: 'Limits describes the maximum amount
+                                              of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              description: 'Requests describes the minimum
+                                              amount of compute resources required. If Requests
+                                              is omitted for a container, it defaults to
+                                              Limits if that is explicitly specified, otherwise
+                                              to an implementation-defined value. More info:
+                                              https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                              type: object
+                                          type: object
+                                        selector:
+                                          description: selector is a label query over volumes
+                                            to consider for binding.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list of label
+                                                selector requirements. The requirements are
+                                                ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values, a key,
+                                                  and an operator that relates the key and
+                                                  values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that
+                                                      the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents a key's
+                                                      relationship to a set of values. Valid
+                                                      operators are In, NotIn, Exists and
+                                                      DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array of string
+                                                      values. If the operator is In or NotIn,
+                                                      the values array must be non-empty.
+                                                      If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This
+                                                      array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of {key,value}
+                                                pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions,
+                                                whose key field is "key", the operator is
+                                                "In", and the values array contains only "value".
+                                                The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        storageClassName:
+                                          description: 'storageClassName is the name of the
+                                          StorageClass required by the claim. More info:
+                                          https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                          type: string
+                                        volumeMode:
+                                          description: volumeMode defines what type of volume
+                                            is required by the claim. Value of Filesystem
+                                            is implied when not included in claim spec.
+                                          type: string
+                                        volumeName:
+                                          description: volumeName is the binding reference
+                                            to the PersistentVolume backing this claim.
+                                          type: string
+                                      type: object
+                                  required:
+                                    - spec
+                                  type: object
+                              type: object
+                            fc:
+                              description: fc represents a Fibre Channel resource that is
+                                attached to a kubelet's host machine and then exposed to the
+                                pod.
+                              properties:
+                                fsType:
+                                  description: 'fsType is the filesystem type to mount. Must
+                                  be a filesystem type supported by the host operating system.
+                                  Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                                  if unspecified. TODO: how do we prevent errors in the
+                                  filesystem from compromising the machine'
+                                  type: string
+                                lun:
+                                  description: 'lun is Optional: FC target lun number'
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  description: 'readOnly is Optional: Defaults to false (read/write).
+                                  ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                                  type: boolean
+                                targetWWNs:
+                                  description: 'targetWWNs is Optional: FC target worldwide
+                                  names (WWNs)'
+                                  items:
+                                    type: string
+                                  type: array
+                                wwids:
+                                  description: 'wwids Optional: FC volume world wide identifiers
+                                  (wwids) Either wwids or combination of targetWWNs and
+                                  lun must be set, but not both simultaneously.'
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            flexVolume:
+                              description: flexVolume represents a generic volume resource
+                                that is provisioned/attached using an exec based plugin.
+                              properties:
+                                driver:
+                                  description: driver is the name of the driver to use for
+                                    this volume.
+                                  type: string
+                                fsType:
+                                  description: fsType is the filesystem type to mount. Must
+                                    be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". The default filesystem depends
+                                    on FlexVolume script.
+                                  type: string
+                                options:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'options is Optional: this field holds extra
+                                  command options if any.'
+                                  type: object
+                                readOnly:
+                                  description: 'readOnly is Optional: defaults to false (read/write).
+                                  ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                                  type: boolean
+                                secretRef:
+                                  description: 'secretRef is Optional: secretRef is reference
+                                  to the secret object containing sensitive information
+                                  to pass to the plugin scripts. This may be empty if no
+                                  secret object is specified. If the secret object contains
+                                  more than one secret, all secrets are passed to the plugin
+                                  scripts.'
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                                - driver
+                              type: object
+                            flocker:
+                              description: flocker represents a Flocker volume attached to
+                                a kubelet's host machine. This depends on the Flocker control
+                                service being running
+                              properties:
+                                datasetName:
+                                  description: datasetName is Name of the dataset stored as
+                                    metadata -> name on the dataset for Flocker should be
+                                    considered as deprecated
+                                  type: string
+                                datasetUUID:
+                                  description: datasetUUID is the UUID of the dataset. This
+                                    is unique identifier of a Flocker dataset
+                                  type: string
+                              type: object
+                            gcePersistentDisk:
+                              description: 'gcePersistentDisk represents a GCE Disk resource
+                              that is attached to a kubelet''s host machine and then exposed
+                              to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              properties:
+                                fsType:
+                                  description: 'fsType is filesystem type of the volume that
+                                  you want to mount. Tip: Ensure that the filesystem type
+                                  is supported by the host operating system. Examples: "ext4",
+                                  "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                  TODO: how do we prevent errors in the filesystem from
+                                  compromising the machine'
+                                  type: string
+                                partition:
+                                  description: 'partition is the partition in the volume that
+                                  you want to mount. If omitted, the default is to mount
+                                  by volume name. Examples: For volume /dev/sda1, you specify
+                                  the partition as "1". Similarly, the volume partition
+                                  for /dev/sda is "0" (or you can leave the property empty).
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  format: int32
+                                  type: integer
+                                pdName:
+                                  description: 'pdName is unique name of the PD resource in
+                                  GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  type: string
+                                readOnly:
+                                  description: 'readOnly here will force the ReadOnly setting
+                                  in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  type: boolean
+                              required:
+                                - pdName
+                              type: object
+                            gitRepo:
+                              description: 'gitRepo represents a git repository at a particular
+                              revision. DEPRECATED: GitRepo is deprecated. To provision
+                              a container with a git repo, mount an EmptyDir into an InitContainer
+                              that clones the repo using git, then mount the EmptyDir into
+                              the Pod''s container.'
+                              properties:
+                                directory:
+                                  description: directory is the target directory name. Must
+                                    not contain or start with '..'.  If '.' is supplied, the
+                                    volume directory will be the git repository.  Otherwise,
+                                    if specified, the volume will contain the git repository
+                                    in the subdirectory with the given name.
+                                  type: string
+                                repository:
+                                  description: repository is the URL
+                                  type: string
+                                revision:
+                                  description: revision is the commit hash for the specified
+                                    revision.
+                                  type: string
+                              required:
+                                - repository
+                              type: object
+                            glusterfs:
+                              description: 'glusterfs represents a Glusterfs mount on the
+                              host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                              properties:
+                                endpoints:
+                                  description: 'endpoints is the endpoint name that details
+                                  Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  type: string
+                                path:
+                                  description: 'path is the Glusterfs volume path. More info:
+                                  https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  type: string
+                                readOnly:
+                                  description: 'readOnly here will force the Glusterfs volume
+                                  to be mounted with read-only permissions. Defaults to
+                                  false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  type: boolean
+                              required:
+                                - endpoints
+                                - path
+                              type: object
+                            hostPath:
+                              description: 'hostPath represents a pre-existing file or directory
+                              on the host machine that is directly exposed to the container.
+                              This is generally used for system agents or other privileged
+                              things that are allowed to see the host machine. Most containers
+                              will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                              --- TODO(jonesdl) We need to restrict who can use host directory
+                              mounts and who can/can not mount host directories as read/write.'
+                              properties:
+                                path:
+                                  description: 'path of the directory on the host. If the
+                                  path is a symlink, it will follow the link to the real
+                                  path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                  type: string
+                                type:
+                                  description: 'type for HostPath Volume Defaults to "" More
+                                  info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                  type: string
+                              required:
+                                - path
+                              type: object
+                            iscsi:
+                              description: 'iscsi represents an ISCSI Disk resource that is
+                              attached to a kubelet''s host machine and then exposed to
+                              the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                              properties:
+                                chapAuthDiscovery:
+                                  description: chapAuthDiscovery defines whether support iSCSI
+                                    Discovery CHAP authentication
+                                  type: boolean
+                                chapAuthSession:
+                                  description: chapAuthSession defines whether support iSCSI
+                                    Session CHAP authentication
+                                  type: boolean
+                                fsType:
+                                  description: 'fsType is the filesystem type of the volume
+                                  that you want to mount. Tip: Ensure that the filesystem
+                                  type is supported by the host operating system. Examples:
+                                  "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                                  if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                  TODO: how do we prevent errors in the filesystem from
+                                  compromising the machine'
+                                  type: string
+                                initiatorName:
+                                  description: initiatorName is the custom iSCSI Initiator
+                                    Name. If initiatorName is specified with iscsiInterface
+                                    simultaneously, new iSCSI interface <target portal>:<volume
+                                    name> will be created for the connection.
+                                  type: string
+                                iqn:
+                                  description: iqn is the target iSCSI Qualified Name.
+                                  type: string
+                                iscsiInterface:
+                                  description: iscsiInterface is the interface Name that uses
+                                    an iSCSI transport. Defaults to 'default' (tcp).
+                                  type: string
+                                lun:
+                                  description: lun represents iSCSI Target Lun number.
+                                  format: int32
+                                  type: integer
+                                portals:
+                                  description: portals is the iSCSI Target Portal List. The
+                                    portal is either an IP or ip_addr:port if the port is
+                                    other than default (typically TCP ports 860 and 3260).
+                                  items:
+                                    type: string
+                                  type: array
+                                readOnly:
+                                  description: readOnly here will force the ReadOnly setting
+                                    in VolumeMounts. Defaults to false.
+                                  type: boolean
+                                secretRef:
+                                  description: secretRef is the CHAP Secret for iSCSI target
+                                    and initiator authentication
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                targetPortal:
+                                  description: targetPortal is iSCSI Target Portal. The Portal
+                                    is either an IP or ip_addr:port if the port is other than
+                                    default (typically TCP ports 860 and 3260).
+                                  type: string
+                              required:
+                                - iqn
+                                - lun
+                                - targetPortal
+                              type: object
+                            name:
+                              description: 'name of the volume. Must be a DNS_LABEL and unique
+                              within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            nfs:
+                              description: 'nfs represents an NFS mount on the host that shares
+                              a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                              properties:
+                                path:
+                                  description: 'path that is exported by the NFS server. More
+                                  info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  type: string
+                                readOnly:
+                                  description: 'readOnly here will force the NFS export to
+                                  be mounted with read-only permissions. Defaults to false.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  type: boolean
+                                server:
+                                  description: 'server is the hostname or IP address of the
+                                  NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  type: string
+                              required:
+                                - path
+                                - server
+                              type: object
+                            persistentVolumeClaim:
+                              description: 'persistentVolumeClaimVolumeSource represents a
+                              reference to a PersistentVolumeClaim in the same namespace.
+                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                              properties:
+                                claimName:
+                                  description: 'claimName is the name of a PersistentVolumeClaim
+                                  in the same namespace as the pod using this volume. More
+                                  info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                  type: string
+                                readOnly:
+                                  description: readOnly Will force the ReadOnly setting in
+                                    VolumeMounts. Default false.
+                                  type: boolean
+                              required:
+                                - claimName
+                              type: object
+                            photonPersistentDisk:
+                              description: photonPersistentDisk represents a PhotonController
+                                persistent disk attached and mounted on kubelets host machine
+                              properties:
+                                fsType:
+                                  description: fsType is the filesystem type to mount. Must
+                                    be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                                    if unspecified.
+                                  type: string
+                                pdID:
+                                  description: pdID is the ID that identifies Photon Controller
+                                    persistent disk
+                                  type: string
+                              required:
+                                - pdID
+                              type: object
+                            portworxVolume:
+                              description: portworxVolume represents a portworx volume attached
+                                and mounted on kubelets host machine
+                              properties:
+                                fsType:
+                                  description: fSType represents the filesystem type to mount
+                                    Must be a filesystem type supported by the host operating
+                                    system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4"
+                                    if unspecified.
+                                  type: string
+                                readOnly:
+                                  description: readOnly defaults to false (read/write). ReadOnly
+                                    here will force the ReadOnly setting in VolumeMounts.
+                                  type: boolean
+                                volumeID:
+                                  description: volumeID uniquely identifies a Portworx volume
+                                  type: string
+                              required:
+                                - volumeID
+                              type: object
+                            projected:
+                              description: projected items for all in one resources secrets,
+                                configmaps, and downward API
+                              properties:
+                                defaultMode:
+                                  description: defaultMode are the mode bits used to set permissions
+                                    on created files by default. Must be an octal value between
+                                    0000 and 0777 or a decimal value between 0 and 511. YAML
+                                    accepts both octal and decimal values, JSON requires decimal
+                                    values for mode bits. Directories within the path are
+                                    not affected by this setting. This might be in conflict
+                                    with other options that affect the file mode, like fsGroup,
+                                    and the result can be other mode bits set.
+                                  format: int32
+                                  type: integer
+                                sources:
+                                  description: sources is the list of volume projections
+                                  items:
+                                    description: Projection that may be projected along with
+                                      other supported volume types
+                                    properties:
+                                      configMap:
+                                        description: configMap information about the configMap
+                                          data to project
+                                        properties:
+                                          items:
+                                            description: items if unspecified, each key-value
+                                              pair in the Data field of the referenced ConfigMap
+                                              will be projected into the volume as a file
+                                              whose name is the key and content is the value.
+                                              If specified, the listed keys will be projected
+                                              into the specified paths, and unlisted keys
+                                              will not be present. If a key is specified which
+                                              is not present in the ConfigMap, the volume
+                                              setup will error unless it is marked optional.
+                                              Paths must be relative and may not contain the
+                                              '..' path or start with '..'.
+                                            items:
+                                              description: Maps a string key to a path within
+                                                a volume.
+                                              properties:
+                                                key:
+                                                  description: key is the key to project.
+                                                  type: string
+                                                mode:
+                                                  description: 'mode is Optional: mode bits
+                                                  used to set permissions on this file.
+                                                  Must be an octal value between 0000 and
+                                                  0777 or a decimal value between 0 and
+                                                  511. YAML accepts both octal and decimal
+                                                  values, JSON requires decimal values for
+                                                  mode bits. If not specified, the volume
+                                                  defaultMode will be used. This might be
+                                                  in conflict with other options that affect
+                                                  the file mode, like fsGroup, and the result
+                                                  can be other mode bits set.'
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  description: path is the relative path of
+                                                    the file to map the key to. May not be
+                                                    an absolute path. May not contain the
+                                                    path element '..'. May not start with
+                                                    the string '..'.
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                              type: object
+                                            type: array
+                                          name:
+                                            description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind,
+                                            uid?'
+                                            type: string
+                                          optional:
+                                            description: optional specify whether the ConfigMap
+                                              or its keys must be defined
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      downwardAPI:
+                                        description: downwardAPI information about the downwardAPI
+                                          data to project
+                                        properties:
+                                          items:
+                                            description: Items is a list of DownwardAPIVolume
+                                              file
+                                            items:
+                                              description: DownwardAPIVolumeFile represents
+                                                information to create the file containing
+                                                the pod field
+                                              properties:
+                                                fieldRef:
+                                                  description: 'Required: Selects a field
+                                                  of the pod: only annotations, labels,
+                                                  name and namespace are supported.'
+                                                  properties:
+                                                    apiVersion:
+                                                      description: Version of the schema the
+                                                        FieldPath is written in terms of,
+                                                        defaults to "v1".
+                                                      type: string
+                                                    fieldPath:
+                                                      description: Path of the field to select
+                                                        in the specified API version.
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                mode:
+                                                  description: 'Optional: mode bits used to
+                                                  set permissions on this file, must be
+                                                  an octal value between 0000 and 0777 or
+                                                  a decimal value between 0 and 511. YAML
+                                                  accepts both octal and decimal values,
+                                                  JSON requires decimal values for mode
+                                                  bits. If not specified, the volume defaultMode
+                                                  will be used. This might be in conflict
+                                                  with other options that affect the file
+                                                  mode, like fsGroup, and the result can
+                                                  be other mode bits set.'
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  description: 'Required: Path is  the relative
+                                                  path name of the file to be created. Must
+                                                  not be absolute or contain the ''..''
+                                                  path. Must be utf-8 encoded. The first
+                                                  item of the relative path must not start
+                                                  with ''..'''
+                                                  type: string
+                                                resourceFieldRef:
+                                                  description: 'Selects a resource of the
+                                                  container: only resources limits and requests
+                                                  (limits.cpu, limits.memory, requests.cpu
+                                                  and requests.memory) are currently supported.'
+                                                  properties:
+                                                    containerName:
+                                                      description: 'Container name: required
+                                                      for volumes, optional for env vars'
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      description: Specifies the output format
+                                                        of the exposed resources, defaults
+                                                        to "1"
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      description: 'Required: resource to
+                                                      select'
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              required:
+                                                - path
+                                              type: object
+                                            type: array
+                                        type: object
+                                      secret:
+                                        description: secret information about the secret data
+                                          to project
+                                        properties:
+                                          items:
+                                            description: items if unspecified, each key-value
+                                              pair in the Data field of the referenced Secret
+                                              will be projected into the volume as a file
+                                              whose name is the key and content is the value.
+                                              If specified, the listed keys will be projected
+                                              into the specified paths, and unlisted keys
+                                              will not be present. If a key is specified which
+                                              is not present in the Secret, the volume setup
+                                              will error unless it is marked optional. Paths
+                                              must be relative and may not contain the '..'
+                                              path or start with '..'.
+                                            items:
+                                              description: Maps a string key to a path within
+                                                a volume.
+                                              properties:
+                                                key:
+                                                  description: key is the key to project.
+                                                  type: string
+                                                mode:
+                                                  description: 'mode is Optional: mode bits
+                                                  used to set permissions on this file.
+                                                  Must be an octal value between 0000 and
+                                                  0777 or a decimal value between 0 and
+                                                  511. YAML accepts both octal and decimal
+                                                  values, JSON requires decimal values for
+                                                  mode bits. If not specified, the volume
+                                                  defaultMode will be used. This might be
+                                                  in conflict with other options that affect
+                                                  the file mode, like fsGroup, and the result
+                                                  can be other mode bits set.'
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  description: path is the relative path of
+                                                    the file to map the key to. May not be
+                                                    an absolute path. May not contain the
+                                                    path element '..'. May not start with
+                                                    the string '..'.
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                              type: object
+                                            type: array
+                                          name:
+                                            description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind,
+                                            uid?'
+                                            type: string
+                                          optional:
+                                            description: optional field specify whether the
+                                              Secret or its key must be defined
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      serviceAccountToken:
+                                        description: serviceAccountToken is information about
+                                          the serviceAccountToken data to project
+                                        properties:
+                                          audience:
+                                            description: audience is the intended audience
+                                              of the token. A recipient of a token must identify
+                                              itself with an identifier specified in the audience
+                                              of the token, and otherwise should reject the
+                                              token. The audience defaults to the identifier
+                                              of the apiserver.
+                                            type: string
+                                          expirationSeconds:
+                                            description: expirationSeconds is the requested
+                                              duration of validity of the service account
+                                              token. As the token approaches expiration, the
+                                              kubelet volume plugin will proactively rotate
+                                              the service account token. The kubelet will
+                                              start trying to rotate the token if the token
+                                              is older than 80 percent of its time to live
+                                              or if the token is older than 24 hours.Defaults
+                                              to 1 hour and must be at least 10 minutes.
+                                            format: int64
+                                            type: integer
+                                          path:
+                                            description: path is the path relative to the
+                                              mount point of the file to project the token
+                                              into.
+                                            type: string
+                                        required:
+                                          - path
+                                        type: object
+                                    type: object
+                                  type: array
+                              type: object
+                            quobyte:
+                              description: quobyte represents a Quobyte mount on the host
+                                that shares a pod's lifetime
+                              properties:
+                                group:
+                                  description: group to map volume access to Default is no
+                                    group
+                                  type: string
+                                readOnly:
+                                  description: readOnly here will force the Quobyte volume
+                                    to be mounted with read-only permissions. Defaults to
+                                    false.
+                                  type: boolean
+                                registry:
+                                  description: registry represents a single or multiple Quobyte
+                                    Registry services specified as a string as host:port pair
+                                    (multiple entries are separated with commas) which acts
+                                    as the central registry for volumes
+                                  type: string
+                                tenant:
+                                  description: tenant owning the given Quobyte volume in the
+                                    Backend Used with dynamically provisioned Quobyte volumes,
+                                    value is set by the plugin
+                                  type: string
+                                user:
+                                  description: user to map volume access to Defaults to serivceaccount
+                                    user
+                                  type: string
+                                volume:
+                                  description: volume is a string that references an already
+                                    created Quobyte volume by name.
+                                  type: string
+                              required:
+                                - registry
+                                - volume
+                              type: object
+                            rbd:
+                              description: 'rbd represents a Rados Block Device mount on the
+                              host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
+                              properties:
+                                fsType:
+                                  description: 'fsType is the filesystem type of the volume
+                                  that you want to mount. Tip: Ensure that the filesystem
+                                  type is supported by the host operating system. Examples:
+                                  "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                                  if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                  TODO: how do we prevent errors in the filesystem from
+                                  compromising the machine'
+                                  type: string
+                                image:
+                                  description: 'image is the rados image name. More info:
+                                  https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  type: string
+                                keyring:
+                                  description: 'keyring is the path to key ring for RBDUser.
+                                  Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  type: string
+                                monitors:
+                                  description: 'monitors is a collection of Ceph monitors.
+                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  items:
+                                    type: string
+                                  type: array
+                                pool:
+                                  description: 'pool is the rados pool name. Default is rbd.
+                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  type: string
+                                readOnly:
+                                  description: 'readOnly here will force the ReadOnly setting
+                                  in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  type: boolean
+                                secretRef:
+                                  description: 'secretRef is name of the authentication secret
+                                  for RBDUser. If provided overrides keyring. Default is
+                                  nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                user:
+                                  description: 'user is the rados user name. Default is admin.
+                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  type: string
+                              required:
+                                - image
+                                - monitors
+                              type: object
+                            scaleIO:
+                              description: scaleIO represents a ScaleIO persistent volume
+                                attached and mounted on Kubernetes nodes.
+                              properties:
+                                fsType:
+                                  description: fsType is the filesystem type to mount. Must
+                                    be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". Default is "xfs".
+                                  type: string
+                                gateway:
+                                  description: gateway is the host address of the ScaleIO
+                                    API Gateway.
+                                  type: string
+                                protectionDomain:
+                                  description: protectionDomain is the name of the ScaleIO
+                                    Protection Domain for the configured storage.
+                                  type: string
+                                readOnly:
+                                  description: readOnly Defaults to false (read/write). ReadOnly
+                                    here will force the ReadOnly setting in VolumeMounts.
+                                  type: boolean
+                                secretRef:
+                                  description: secretRef references to the secret for ScaleIO
+                                    user and other sensitive information. If this is not provided,
+                                    Login operation will fail.
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                sslEnabled:
+                                  description: sslEnabled Flag enable/disable SSL communication
+                                    with Gateway, default false
+                                  type: boolean
+                                storageMode:
+                                  description: storageMode indicates whether the storage for
+                                    a volume should be ThickProvisioned or ThinProvisioned.
+                                    Default is ThinProvisioned.
+                                  type: string
+                                storagePool:
+                                  description: storagePool is the ScaleIO Storage Pool associated
+                                    with the protection domain.
+                                  type: string
+                                system:
+                                  description: system is the name of the storage system as
+                                    configured in ScaleIO.
+                                  type: string
+                                volumeName:
+                                  description: volumeName is the name of a volume already
+                                    created in the ScaleIO system that is associated with
+                                    this volume source.
+                                  type: string
+                              required:
+                                - gateway
+                                - secretRef
+                                - system
+                              type: object
+                            secret:
+                              description: 'secret represents a secret that should populate
+                              this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                              properties:
+                                defaultMode:
+                                  description: 'defaultMode is Optional: mode bits used to
+                                  set permissions on created files by default. Must be an
+                                  octal value between 0000 and 0777 or a decimal value between
+                                  0 and 511. YAML accepts both octal and decimal values,
+                                  JSON requires decimal values for mode bits. Defaults to
+                                  0644. Directories within the path are not affected by
+                                  this setting. This might be in conflict with other options
+                                  that affect the file mode, like fsGroup, and the result
+                                  can be other mode bits set.'
+                                  format: int32
+                                  type: integer
+                                items:
+                                  description: items If unspecified, each key-value pair in
+                                    the Data field of the referenced Secret will be projected
+                                    into the volume as a file whose name is the key and content
+                                    is the value. If specified, the listed keys will be projected
+                                    into the specified paths, and unlisted keys will not be
+                                    present. If a key is specified which is not present in
+                                    the Secret, the volume setup will error unless it is marked
+                                    optional. Paths must be relative and may not contain the
+                                    '..' path or start with '..'.
+                                  items:
+                                    description: Maps a string key to a path within a volume.
+                                    properties:
+                                      key:
+                                        description: key is the key to project.
+                                        type: string
+                                      mode:
+                                        description: 'mode is Optional: mode bits used to
+                                        set permissions on this file. Must be an octal value
+                                        between 0000 and 0777 or a decimal value between
+                                        0 and 511. YAML accepts both octal and decimal values,
+                                        JSON requires decimal values for mode bits. If not
+                                        specified, the volume defaultMode will be used.
+                                        This might be in conflict with other options that
+                                        affect the file mode, like fsGroup, and the result
+                                        can be other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: path is the relative path of the file
+                                          to map the key to. May not be an absolute path.
+                                          May not contain the path element '..'. May not start
+                                          with the string '..'.
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                optional:
+                                  description: optional field specify whether the Secret or
+                                    its keys must be defined
+                                  type: boolean
+                                secretName:
+                                  description: 'secretName is the name of the secret in the
+                                  pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                  type: string
+                              type: object
+                            storageos:
+                              description: storageOS represents a StorageOS volume attached
+                                and mounted on Kubernetes nodes.
+                              properties:
+                                fsType:
+                                  description: fsType is the filesystem type to mount. Must
+                                    be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                                    if unspecified.
+                                  type: string
+                                readOnly:
+                                  description: readOnly defaults to false (read/write). ReadOnly
+                                    here will force the ReadOnly setting in VolumeMounts.
+                                  type: boolean
+                                secretRef:
+                                  description: secretRef specifies the secret to use for obtaining
+                                    the StorageOS API credentials.  If not specified, default
+                                    values will be attempted.
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                volumeName:
+                                  description: volumeName is the human-readable name of the
+                                    StorageOS volume.  Volume names are only unique within
+                                    a namespace.
+                                  type: string
+                                volumeNamespace:
+                                  description: volumeNamespace specifies the scope of the
+                                    volume within StorageOS.  If no namespace is specified
+                                    then the Pod's namespace will be used.  This allows the
+                                    Kubernetes name scoping to be mirrored within StorageOS
+                                    for tighter integration. Set VolumeName to any name to
+                                    override the default behaviour. Set to "default" if you
+                                    are not using namespaces within StorageOS. Namespaces
+                                    that do not pre-exist within StorageOS will be created.
+                                  type: string
+                              type: object
+                            vsphereVolume:
+                              description: vsphereVolume represents a vSphere volume attached
+                                and mounted on kubelets host machine
+                              properties:
+                                fsType:
+                                  description: fsType is filesystem type to mount. Must be
+                                    a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                                    if unspecified.
+                                  type: string
+                                storagePolicyID:
+                                  description: storagePolicyID is the storage Policy Based
+                                    Management (SPBM) profile ID associated with the StoragePolicyName.
+                                  type: string
+                                storagePolicyName:
+                                  description: storagePolicyName is the storage Policy Based
+                                    Management (SPBM) profile name.
+                                  type: string
+                                volumePath:
+                                  description: volumePath is the path that identifies vSphere
+                                    volume vmdk
+                                  type: string
+                              required:
+                                - volumePath
+                              type: object
+                          required:
+                            - name
+                          type: object
+                        type: array
+                      volumeMounts:
+                        description: VolumeMounts allows configuration of additional VolumeMounts
+                          on the output StatefulSet definition. VolumeMounts specified will
+                          be appended to other VolumeMounts in the prometheus container, that
+                          are generated as a result of StorageSpec objects.
+                        items:
+                          description: VolumeMount describes a mounting of a Volume within
+                            a container.
+                          properties:
+                            mountPath:
+                              description: Path within the container at which the volume should
+                                be mounted.  Must not contain ':'.
+                              type: string
+                            mountPropagation:
+                              description: mountPropagation determines how mounts are propagated
+                                from the host to container and the other way around. When
+                                not set, MountPropagationNone is used. This field is beta
+                                in 1.10.
+                              type: string
+                            name:
+                              description: This must match the Name of a Volume.
+                              type: string
+                            readOnly:
+                              description: Mounted read-only if true, read-write otherwise
+                                (false or unspecified). Defaults to false.
+                              type: boolean
+                            subPath:
+                              description: Path within the volume from which the container's
+                                volume should be mounted. Defaults to "" (volume's root).
+                              type: string
+                            subPathExpr:
+                              description: Expanded path within the volume from which the
+                                container's volume should be mounted. Behaves similarly to
+                                SubPath but environment variable references $(VAR_NAME) are
+                                expanded using the container's environment. Defaults to ""
+                                (volume's root). SubPathExpr and SubPath are mutually exclusive.
+                              type: string
+                          required:
+                            - mountPath
+                            - name
+                          type: object
+                        type: array
+                  grafana:
+                    type: object
+                    description: Contains configuration of Grafana to monitor the storage cluster.
+                    properties:
+                      enabled:
+                        type: boolean
+                        description: Flag indicating whether Grafana stack needs to be enabled and deployed
+                          by the Storage operator.
                   telemetry:
                     type: object
                     description: Contains telemetry configuration for the storage cluster.
@@ -916,6 +3397,9 @@ spec:
                       image:
                         type: string
                         description: Docker image of the telemetry container.
+                      logUploaderImage:
+                        type: string
+                        description: Docker image of the log-upload-service container.
               security:
                 type: object
                 description: Contains security configuration for the storage cluster.
@@ -1316,6 +3800,9 @@ spec:
                 description: Phase of the StorageCluster is a simple, high-level summary of where the
                   StorageCluster is in its lifecycle. The condition array contains more detailed
                   information about the state of the cluster.
+              reason:
+                type: string
+                description: CamelCase messages split with commas indicating details about why the StorageCluster is in this state.
               collisionCount:
                 type: integer
                 format: int32
@@ -1379,6 +3866,9 @@ spec:
                   prometheus:
                     type: string
                     description: Desired image for Prometheus.
+                  grafana:
+                    type: string
+                    description: Desired image for Grafana.
                   alertManager:
                     type: string
                     description: Desired image for AlertManager.
@@ -1391,22 +3881,50 @@ spec:
                   metricsCollectorProxy:
                     type: string
                     description: Desired image for metrics collector proxy.
+                  telemetryProxy:
+                    type: string
+                    description: Desired image for telemetry proxy.
+                  logUploader:
+                    type: string
+                    description: Desired image for log uploader.
+                  kubeScheduler:
+                    type: string
+                    description: Desired image for kubernetes scheduler.
+                  kubeControllerManager:
+                    type: string
+                    description: Desired image for kubernetes controller manager.
+                  pause:
+                    type: string
+                    description: Desired image for pause image.
+                  dynamicPlugin:
+                    type: string
+                    description: Desired image for dynamic plugin image.
+                  dynamicPluginProxy:
+                    type: string
+                    description: Desired image for nginx proxy image.
               conditions:
                 type: array
                 description: Contains details for the current condition of this cluster.
                 items:
                   type: object
                   properties:
+                    source:
+                      type: string
+                      description: Name of the component.
                     type:
                       type: string
                       description: Type of the condition.
                     status:
                       type: string
                       description: Status of the condition.
-                    reason:
+                    message:
                       type: string
-                      description: Reason is human readable message indicating details about the current
+                      description: Message is human readable message indicating details about the current
                         state of the cluster.
+                    lastTransitionTime:
+                      type: string
+                      format: date-time
+                      description: Time at which the condition changed.
   - name: v1alpha1
     served: false
     storage: false

--- a/charts/portworx/crds/core_v1_storagenode_crd.yaml
+++ b/charts/portworx/crds/core_v1_storagenode_crd.yaml
@@ -133,6 +133,24 @@ spec:
                       type: string
                       format: date-time
                       description: Time at which the condition changed.
+              checks:
+                type: array
+                description: Contains list of pre or post flight checks that are performed by the Operator
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                      description: Type of the check.
+                    reason:
+                      type: string
+                      description: Reason for success or failure of the check
+                    success:
+                      type: boolean
+                      description: If true, the check was successful
+                    result:
+                      type: string
+                      description: Result of the check fatal, warning, success
               geography:
                 type: object
                 description: Contains topology information for the storage node.
@@ -146,6 +164,22 @@ spec:
                   rack:
                     type: string
                     description: Rack on which the storage node is placed.
+              operatingSystem:
+                type: string
+                description: Operating system of the underlying host.
+              kernelVersion:
+                type: string
+                description: Kernel version of the underlying host.
+              nodeAttributes:
+                type: object
+                description: Attributes of the storage node.
+                properties:
+                  storage:
+                    type: boolean
+                    description: Indicates whether the node is a storage node or not.
+                  kvdb:
+                    type: boolean
+                    description: Indicates whether the node is a kvdb node or not.
   - name: v1alpha1
     served: false
     storage: false


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: Currently the CRD of storagecluster used in helm chart install is different from what the operator installs. This causes an issue when the CRD created by operator is overwritten by the CRD in helm. The mismatch in Status.Conditions fields between the 2 causes operator to continue appending status to the stc increasing its size infinitely. After updating the helm CRD, this issue will not be faced.

**Which issue(s) this PR fixes** (optional)
Closes # PWX-35781

**Testing notes**:
This includes the steps to reproduce the issue as well as fix it
1. Deploy operator and stc 
2. Update the crd of `storageclusters.core.libopenstorage.org` with the [older CRD](https://github.com/portworx/helm/blob/master/charts/portworx/crds/core_v1_storagecluster_crd.yaml) from helm. 
3. Wait for 10-15 minutes, there will be multiple entries of conditions
4. Now update the CRD to the latest version and wait for another 10 minutes
5. The conditions field stops having any more entries.