### PR TITLE
PB-7411: Update heartbeatTimeoutSecs,electionTimeoutMillis for the pxcentral mongodb template.

### DIFF
--- a/charts/px-central/templates/px-backup/pxcentral-mongodb.yaml
+++ b/charts/px-central/templates/px-backup/pxcentral-mongodb.yaml
@@ -25,6 +25,28 @@ data:
     echo "Advertised Hostname: $MONGODB_ADVERTISED_HOSTNAME"
     echo "Advertised Service: $K8S_SERVICE_NAME"
 
+    if [[ "$MY_POD_NAME" = "pxc-backup-mongodb-0" ]]; then
+      echo "This node is currently PRIMARY - will apply rs.conf settings"
+
+      usernameAndPassword="-u ${MONGODB_ROOT_USER} -p ${MONGODB_ROOT_PASSWORD}"
+      settingsToConfigure="${settingsToConfigure}cfg.settings.heartbeatTimeoutSecs = 60; "
+      settingsToConfigure="${settingsToConfigure}cfg.settings.electionTimeoutMillis = 20000; "
+
+      # avoiding tricky string substitution with single quotes by making the eval string a set of vars
+      rsconf="cfg = rs.conf();"
+      rsreconf="rs.reconfig(cfg);"
+      rsCommand="${rsconf} ${settingsToConfigure} ${rsreconf}"
+
+      mongosh ${usernameAndPassword} --eval "${rsCommand}"
+      if [ $? -ne 0 ]; then
+        logger "Failed to apply mongodb cfg.settings configuration"
+      else
+        logger "mongodb replicaset cfg.settings configuration applied"
+        logger "Will check rs conf"
+        # don't exit just yet - the settings will be checked in the next loop
+      fi  
+    fi
+
     # Check for existing replica set in case there is no data in the PVC
     # This is for cases where the PVC is lost or for MongoDB caches without
     # persistence


### PR DESCRIPTION
For pxcental mongodb template: Apply replicaset(rs) reconfig by increasing the heartbeatTimeoutSecs and electionTimeoutMillis

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
To fix the px-backup pod crash issue as the mongoDB went into the non-writable state.

**Which issue(s) this PR fixes** (optional)
Closes #PB-7411

**Special notes for your reviewer**:
![Screenshot from 2024-06-29 20-11-06](https://github.com/portworx/helm/assets/116876049/cd0df100-00e7-4c97-a497-3810ca01ec10)
![Screenshot from 2024-06-29 19-58-51](https://github.com/portworx/helm/assets/116876049/e3ede27d-08e6-4b03-a3f7-7f7557487746)

