### PR TITLE
PWX-37682 | Add missing field for StorageCluster Spec in helm

### DIFF
--- a/charts/portworx/templates/storage-cluster.yaml
+++ b/charts/portworx/templates/storage-cluster.yaml
@@ -28,6 +28,12 @@
   {{- $journalDevice := .Values.journalDevice | default "none" }}
   {{- $miscArgs := include "px.miscArgs" . }}
   {{- $volumesPresent := include "px.volumesPresent" . }}
+  {{- $storagePodAnnotations := .Values.customMetadata.annotations.pod.storage }}
+  {{- $portworxApiServiceAnnotations := .Values.customMetadata.annotations.service.portworxApi }}
+  {{- $portworxServiceAnnotations := .Values.customMetadata.annotations.service.portworxService }}
+  {{- $kvdbServiceAnnotations := .Values.customMetadata.annotations.service.portworxKVDBService }}
+  {{- $portworxApiServiceLabels := .Values.customMetadata.labels.service.portworxApi}}
+
 
 kind: StorageCluster
 apiVersion: core.libopenstorage.org/v1
@@ -79,6 +85,65 @@ spec:
   {{- end }}
   {{- if not (eq $registrySecret "none") }}
   imagePullSecret: {{ $registrySecret }}
+  {{- end }}
+
+
+  {{- $hasAnnotations := or ($storagePodAnnotations) ($portworxApiServiceAnnotations) ($portworxServiceAnnotations ) ($kvdbServiceAnnotations) }}
+  {{- $hasLabels := $portworxApiServiceLabels }}
+  {{- $hasMetadata := or $hasAnnotations $hasLabels }}
+
+  {{- if $hasMetadata}}
+  metadata:
+    {{- if $hasLabels}}
+    labels:
+      {{- if $portworxApiServiceLabels }}
+      service/portworx-api:
+        {{- $labels := $portworxApiServiceLabels | split ";" }}
+        {{- range $key, $val := $labels }}
+        {{- $label := $val | split "=" }}
+          {{ $label._0 | trim }}: {{ $label._1 | trim | quote -}}
+        {{- end }}
+      {{- end }}
+    {{- end}}
+    {{- if $hasAnnotations}}
+    annotations:
+      {{- if $storagePodAnnotations }}
+      pod/storage:
+        {{- $annotations := $storagePodAnnotations | split ";" }}
+        {{- range $key, $val := $annotations }}
+        {{- $annotation := $val | split "=" }}
+          {{ $annotation._0 | trim }}: {{ $annotation._1 | trim | quote -}}
+        {{- end }}
+      {{- end }}
+
+      {{- if $portworxApiServiceAnnotations }}
+      service/portworx-api:
+        {{- $annotations := $portworxApiServiceAnnotations | split ";" }}
+        {{- range $key, $val := $annotations }}
+        {{- $annotation := $val | split "=" }}
+          {{ $annotation._0 | trim }}: {{ $annotation._1 | trim | quote -}}
+        {{- end }}
+      {{- end }}
+
+      {{- if $portworxServiceAnnotations }}
+      service/portworx-service:
+        {{- $annotations := $portworxServiceAnnotations | split ";" }}
+        {{- range $key, $val := $annotations }}
+        {{- $annotation := $val | split "=" }}
+          {{ $annotation._0 | trim }}: {{ $annotation._1 | trim | quote -}}
+        {{- end }}
+      {{- end }}
+
+      {{- if $kvdbServiceAnnotations }}
+      service/portworx-kvdb-service:
+        {{- $annotations := $kvdbServiceAnnotations | split ";" }}
+        {{- range $key, $val := $annotations }}
+        {{- $annotation := $val | split "=" }}
+          {{ $annotation._0 | trim }}: {{ $annotation._1 | trim | quote -}}
+        {{- end }}
+      {{- end }}    
+
+    {{- end}}
   {{- end }}
 
   kvdb:
@@ -344,6 +409,11 @@ spec:
         issuer: {{.Values.security.auth.selfSigned.issuer}}
         sharedSecret: {{.Values.security.auth.selfSigned.sharedSecret}}
       {{- end}}
+  {{- end}}
+
+  {{- with .Values.resources }}
+  resources:
+    {{- toYaml . | nindent 4  }}
   {{- end}}
 
   {{- with .Values.tolerations }}

--- a/charts/portworx/templates/storage-cluster.yaml
+++ b/charts/portworx/templates/storage-cluster.yaml
@@ -313,6 +313,39 @@ spec:
     enabled: true
   {{- end }}
 
+  {{- if .Values.runtimeOptions }}
+  runtimeOptions:
+  {{- $args := .Values.runtimeOptions | split ";" }}
+  {{- range $key, $val := $args }}
+  {{- $arg := $val | split "=" }}
+    {{ $arg._0 | trim }}: {{ $arg._1 | trim | quote -}}
+  {{- end }}
+  {{- end }}
+
+  {{- if .Values.featureGates }}
+  featureGates:
+  {{- $args := .Values.featureGates | split ";" }}
+  {{- range $key, $val := $args }}
+  {{- $arg := $val | split "=" }}
+    {{ $arg._0 | trim }}: {{ $arg._1 | trim | quote -}}
+  {{- end }}
+  {{- end }}
+
+  {{- if eq .Values.security.enabled true}}
+  security: 
+    enabled: true
+    auth:
+      {{- if (or (eq .Values.security.auth.guestAccess "Enabled") (eq .Values.security.auth.guestAccess "Disabled") (eq .Values.security.auth.guestAccess "Managed"))}}
+      guestAccess: {{.Values.security.auth.guestAccess}}
+      {{- end}}
+      {{- if and .Values.security.auth.selfSigned.tokenLifetime .Values.security.auth.selfSigned.issuer .Values.security.auth.selfSigned.sharedSecret }}
+      selfSigned:
+        tokenLifetime: {{.Values.security.auth.selfSigned.tokenLifetime}}
+        issuer: {{.Values.security.auth.selfSigned.issuer}}
+        sharedSecret: {{.Values.security.auth.selfSigned.sharedSecret}}
+      {{- end}}
+  {{- end}}
+
   {{- with .Values.tolerations }}
   placement:
     tolerations:

--- a/charts/portworx/values.yaml
+++ b/charts/portworx/values.yaml
@@ -3,7 +3,7 @@
 deployOperator: true                    # Deploy the Portworx operator
 deployCluster: true                     # Deploy the Portworx cluster
 
-imageVersion: 3.0.5                  # Version of the PX Image.
+imageVersion: 3.1.0                  # Version of the PX Image.
 pxOperatorImageVersion: 23.10.2           # Version of the PX operator image.
 
 openshiftInstall: false                 # Defaults to false for installing Portworx on Openshift .
@@ -36,7 +36,7 @@ runtimeOptions:                       # A collection of key-value pairs that ove
 featureGates:                         # A collection of key-value pairs specifying which Portworx features should be enabled or disabled.
 
 security: 
-  enabled: true                       # Enables or disables Security at any given time.
+  enabled: false                      # Enables or disables Security at any given time.
   auth:
     guestAccess: Enabled              # Determines how the guest role will be updated in your cluster. The options are Enabled, Disabled, or Managed. 
     selfSigned:                      

--- a/charts/portworx/values.yaml
+++ b/charts/portworx/values.yaml
@@ -44,6 +44,25 @@ security:
       issuer:                         # The issuer name to be used when configuring PX-Security. This field maps to the PORTWORX_AUTH_JWT_ISSUER environment variable in the Portworx Daemonset.
       sharedSecret:                   # The Kubernetes secret name for retrieving and storing your shared secret.
 
+resources:                            # Configure Portworx container usage such as memory and CPU usage
+  # requests:
+  #   memory: "64Mi"
+  #   cpu: "250m"
+
+customMetadata:                       # Configure custom labels and annotation for specific pod and services
+                                      # Pass labels and annotation with ";" sperated list. Example: application=my-app;environment=production
+  annotations:                        # Currently, custom annotations are supported on following types of components:
+    pod:
+      storage: ""
+    service:
+      portworxApi: ""
+      portworxService: ""
+      portworxKVDBService: ""
+  labels:                             # Currently, custom labels are only supported on the portworx-api service
+    service: 
+      portworxApi: ""
+
+
 envVars: none                         # DEPRECATED: Use envs section to set env variables
                                       # NOTE: This is a ";" seperated list of environment variables.
                                       # For eg: MYENV1=myvalue1;MYENV2=myvalue2

--- a/charts/portworx/values.yaml
+++ b/charts/portworx/values.yaml
@@ -3,7 +3,7 @@
 deployOperator: true                    # Deploy the Portworx operator
 deployCluster: true                     # Deploy the Portworx cluster
 
-imageVersion: 3.1.0                    # Version of the PX Image.
+imageVersion: 3.0.5                  # Version of the PX Image.
 pxOperatorImageVersion: 23.10.2           # Version of the PX operator image.
 
 openshiftInstall: false                 # Defaults to false for installing Portworx on Openshift .
@@ -31,6 +31,18 @@ managementInterface: none             # Name of the interface <ethX>
 serviceType: none                     # Kubernetes service type for services deployed by the Operator. Direct Values like
                                       # 'LoadBalancer', 'NodePort' will change all services. To change the types of specific
                                       # services, value can be specified as 'portworx-service:LoadBalancer;portworx-api:ClusterIP'
+
+runtimeOptions:                       # A collection of key-value pairs that overwrites the runtime options.
+featureGates:                         # A collection of key-value pairs specifying which Portworx features should be enabled or disabled.
+
+security: 
+  enabled: true                       # Enables or disables Security at any given time.
+  auth:
+    guestAccess: Enabled              # Determines how the guest role will be updated in your cluster. The options are Enabled, Disabled, or Managed. 
+    selfSigned:                      
+      tokenLifetime:                  # The length operator-generated tokens will be alive until being refreshed.
+      issuer:                         # The issuer name to be used when configuring PX-Security. This field maps to the PORTWORX_AUTH_JWT_ISSUER environment variable in the Portworx Daemonset.
+      sharedSecret:                   # The Kubernetes secret name for retrieving and storing your shared secret.
 
 envVars: none                         # DEPRECATED: Use envs section to set env variables
                                       # NOTE: This is a ";" seperated list of environment variables.

--- a/test/portworx/storagecluster_helm_template_test.go
+++ b/test/portworx/storagecluster_helm_template_test.go
@@ -93,6 +93,20 @@ func TestStorageClusterHelmTemplate(t *testing.T) {
 				ValuesFiles: []string{"./testValues/storagecluster_security_disabled.yaml"},
 			},
 		},
+		{
+			name:           "TestPortworxContainerResources",
+			resultFileName: "storagecluster_portworx_container_resources.yaml",
+			helmOption: &helm.Options{
+				ValuesFiles: []string{"./testValues/storagecluster_portworx_container_resources.yaml"},
+			},
+		},
+		{
+			name:           "TestCustomMetadata",
+			resultFileName: "storagecluster_custom_metadata.yaml",
+			helmOption: &helm.Options{
+				ValuesFiles: []string{"./testValues/storagecluster_custom_metadata.yaml"},
+			},
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/test/portworx/storagecluster_helm_template_test.go
+++ b/test/portworx/storagecluster_helm_template_test.go
@@ -59,6 +59,40 @@ func TestStorageClusterHelmTemplate(t *testing.T) {
 				ValuesFiles: []string{"./testValues/storagecluster_placement.yaml"},
 			},
 		},
+		{
+			name:           "TestRuntimeOptions",
+			resultFileName: "storagecluster_runtimeOptions.yaml",
+			helmOption: &helm.Options{
+				SetValues: map[string]string{
+					"runtimeOptions": "num_io_threads=10",
+					"internalKVDB":"true",
+				},
+			},
+		},
+		{
+			name:           "TestFeatureGates",
+			resultFileName: "storagecluster_featureGates.yaml",
+			helmOption: &helm.Options{
+				SetValues: map[string]string{
+					"featureGates": "CSI=true",
+					"internalKVDB":"true",
+				},
+			},
+		},
+		{
+			name:           "TestSecurityEnabled",
+			resultFileName: "storagecluster_security_enabled.yaml",
+			helmOption: &helm.Options{
+				ValuesFiles: []string{"./testValues/storagecluster_security_enabled.yaml"},
+			},
+		},
+		{
+			name:           "TestSecurityDisabled",
+			resultFileName: "storagecluster_with_default_values.yaml",
+			helmOption: &helm.Options{
+				ValuesFiles: []string{"./testValues/storagecluster_security_disabled.yaml"},
+			},
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/test/portworx/testValues/storagecluster_custom_metadata.yaml
+++ b/test/portworx/testValues/storagecluster_custom_metadata.yaml
@@ -1,0 +1,12 @@
+internalKVDB: true
+customMetadata:                      
+  annotations:                       
+    pod:
+      storage: "application=my-app;environment=testing"
+    service:
+      portworxApi: "application=my-app;environment=testing"
+      portworxService: "application=my-app;environment=testing"
+      portworxKVDBService: "application=my-app;environment=testing"
+  labels:                          
+    service: 
+      portworxApi: "application=my-app;environment=testing"

--- a/test/portworx/testValues/storagecluster_portworx_container_resources.yaml
+++ b/test/portworx/testValues/storagecluster_portworx_container_resources.yaml
@@ -1,0 +1,5 @@
+internalKVDB: true
+resources:                       
+  requests:
+    memory: "64Mi"
+    cpu: "250m"

--- a/test/portworx/testValues/storagecluster_security_disabled.yaml
+++ b/test/portworx/testValues/storagecluster_security_disabled.yaml
@@ -1,0 +1,9 @@
+internalKVDB: true
+security: 
+  enabled: false                    
+  auth:
+    guestAccess: Enabled             
+    selfSigned:                      
+      tokenLifetime: "24h"                
+      issuer:    "my-issuer"                  
+      sharedSecret: "px-shared-secret"

--- a/test/portworx/testValues/storagecluster_security_enabled.yaml
+++ b/test/portworx/testValues/storagecluster_security_enabled.yaml
@@ -1,0 +1,9 @@
+internalKVDB: true
+security: 
+  enabled: true                    
+  auth:
+    guestAccess: Enabled             
+    selfSigned:                      
+      tokenLifetime: "24h"                
+      issuer:    "my-issuer"                  
+      sharedSecret: "px-shared-secret"

--- a/test/portworx/testspec/storagecluster_custom_metadata.yaml
+++ b/test/portworx/testspec/storagecluster_custom_metadata.yaml
@@ -1,0 +1,48 @@
+kind: StorageCluster
+apiVersion: core.libopenstorage.org/v1
+metadata:
+  name: "mycluster"
+  namespace: kube-system
+  annotations:
+  labels:
+    heritage: "Helm"
+    release: "my-release"
+    chart: "portworx-3.1.0"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "my-release"
+spec:
+  image: portworx/oci-monitor:3.1.0
+  imagePullPolicy: Always
+  metadata:
+    labels:
+      service/portworx-api:
+          application: "my-app"
+          environment: "testing"
+    annotations:
+      pod/storage:
+          application: "my-app"
+          environment: "testing"
+      service/portworx-api:
+          application: "my-app"
+          environment: "testing"
+      service/portworx-service:
+          application: "my-app"
+          environment: "testing"
+      service/portworx-kvdb-service:
+          application: "my-app"
+          environment: "testing"
+
+  kvdb:
+    internal: true
+  storage:
+    useAll: true
+  secretsProvider: k8s
+
+  env:
+  - name: PX_SECRETS_NAMESPACE
+    value: portworx
+
+  stork:
+    enabled: true
+  csi:
+    enabled: false

--- a/test/portworx/testspec/storagecluster_featureGates.yaml
+++ b/test/portworx/testspec/storagecluster_featureGates.yaml
@@ -1,0 +1,32 @@
+kind: StorageCluster
+apiVersion: core.libopenstorage.org/v1
+metadata:
+  name: "mycluster"
+  namespace: kube-system
+  annotations:
+  labels:
+    heritage: "Helm"
+    release: "my-release"
+    chart: "portworx-3.1.0"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "my-release"
+spec:
+  image: portworx/oci-monitor:3.1.0
+  imagePullPolicy: Always
+
+  kvdb:
+    internal: true
+  storage:
+    useAll: true
+  secretsProvider: k8s
+
+  env:
+  - name: PX_SECRETS_NAMESPACE
+    value: portworx
+
+  stork:
+    enabled: true
+  featureGates:
+    CSI: "true"
+  csi:
+    enabled: false

--- a/test/portworx/testspec/storagecluster_portworx_container_resources.yaml
+++ b/test/portworx/testspec/storagecluster_portworx_container_resources.yaml
@@ -1,0 +1,34 @@
+kind: StorageCluster
+apiVersion: core.libopenstorage.org/v1
+metadata:
+  name: "mycluster"
+  namespace: kube-system
+  annotations:
+  labels:
+    heritage: "Helm"
+    release: "my-release"
+    chart: "portworx-3.1.0"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "my-release"
+spec:
+  image: portworx/oci-monitor:3.1.0
+  imagePullPolicy: Always
+
+  kvdb:
+    internal: true
+  storage:
+    useAll: true
+  secretsProvider: k8s
+
+  env:
+  - name: PX_SECRETS_NAMESPACE
+    value: portworx
+
+  stork:
+    enabled: true
+  csi:
+    enabled: false
+  resources:
+    requests:
+      cpu: 250m
+      memory: 64Mi

--- a/test/portworx/testspec/storagecluster_runtimeOptions.yaml
+++ b/test/portworx/testspec/storagecluster_runtimeOptions.yaml
@@ -1,0 +1,32 @@
+kind: StorageCluster
+apiVersion: core.libopenstorage.org/v1
+metadata:
+  name: "mycluster"
+  namespace: kube-system
+  annotations:
+  labels:
+    heritage: "Helm"
+    release: "my-release"
+    chart: "portworx-3.1.0"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "my-release"
+spec:
+  image: portworx/oci-monitor:3.1.0
+  imagePullPolicy: Always
+
+  kvdb:
+    internal: true
+  storage:
+    useAll: true
+  secretsProvider: k8s
+
+  env:
+  - name: PX_SECRETS_NAMESPACE
+    value: portworx
+
+  stork:
+    enabled: true
+  runtimeOptions:
+    num_io_threads: "10"
+  csi:
+    enabled: false

--- a/test/portworx/testspec/storagecluster_security_enabled.yaml
+++ b/test/portworx/testspec/storagecluster_security_enabled.yaml
@@ -1,0 +1,38 @@
+kind: StorageCluster
+apiVersion: core.libopenstorage.org/v1
+metadata:
+  name: "mycluster"
+  namespace: kube-system
+  annotations:
+  labels:
+    heritage: "Helm"
+    release: "my-release"
+    chart: "portworx-3.1.0"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "my-release"
+spec:
+  image: portworx/oci-monitor:3.1.0
+  imagePullPolicy: Always
+
+  kvdb:
+    internal: true
+  storage:
+    useAll: true
+  secretsProvider: k8s
+
+  env:
+  - name: PX_SECRETS_NAMESPACE
+    value: portworx
+
+  stork:
+    enabled: true
+  csi:
+    enabled: false
+  security: 
+    enabled: true
+    auth:
+      guestAccess: Enabled
+      selfSigned:
+        tokenLifetime: 24h
+        issuer: my-issuer
+        sharedSecret: px-shared-secret

--- a/test/utils/test_utils.go
+++ b/test/utils/test_utils.go
@@ -26,6 +26,7 @@ func TestRenderedHelmTemplate(t *testing.T, helmOptions *helm.Options, helmChart
 
 	output := helm.RenderTemplate(t, helmOptions, helmChartPath, "my-release", []string{fmt.Sprintf("templates/%v", renderTemplateFileName)})
 
+	fmt.Printf("------->%s\n",output)
 	var storageCluster interface{}
 	helm.UnmarshalK8SYaml(t, output, &storageCluster)
 


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
This will following fields in the storageClusterSpec
```yaml
runtimeOptions:       map[string]string              
featureGates:     map[string]string                  
metadata:
  annotation: object
  labels: object
security: 
  enabled: bool                    
  auth:
    guestAccess: string            
    selfSigned:                      
      tokenLifetime:  string
      issuer: string                     
      sharedSecret:  string
```

**Which issue(s) this PR fixes** (optional)
Closes #https://purestorage.atlassian.net/browse/PWX-37682

**Special notes for your reviewer**:

