### PR TITLE
PWX-38542 | Resolved adding useAll if drives are provided in values

### DIFF
--- a/charts/portworx/templates/storage-cluster.yaml
+++ b/charts/portworx/templates/storage-cluster.yaml
@@ -259,7 +259,8 @@ spec:
     {{- end }}
     {{- if eq $usedrivesAndPartitions true }}
     useAllWithPartitions: true
-    {{- else }}
+    {{- end}}
+    {{- if and (eq $usedrivesAndPartitions false) (eq $drives "none")}}
     useAll: true
     {{- end }}
     {{- if and (ne $kvdbDevice "none") (hasPrefix "/" $kvdbDevice) }}

--- a/test/portworx/storagecluster_helm_template_test.go
+++ b/test/portworx/storagecluster_helm_template_test.go
@@ -20,10 +20,16 @@ func TestStorageClusterHelmTemplate(t *testing.T) {
 	require.NoError(t, err)
 
 	testCases := []struct {
-		name           string
-		helmOption     *helm.Options
-		resultFileName string
+		name             string
+		helmOption       *helm.Options
+		resultFileName   string
+		expectedErrorMsg string
 	}{
+		{
+			name:             "Failed: NoEtcdConfigurationProvided",
+			expectedErrorMsg: "A valid ETCD url in the format etcd:http://<your-etcd-endpoint> is required.",
+			helmOption:       &helm.Options{},
+		},
 		{
 			name:           "TestAllComponentsEnabled",
 			resultFileName: "storagecluster_all_compenents_enabled.yaml",
@@ -234,10 +240,31 @@ func TestStorageClusterHelmTemplate(t *testing.T) {
 			},
 		},
 		{
-			name:           "TestStorageSpec",
-			resultFileName: "storagecluster_storage.yaml",
+			name:           "TestStorageSpecDevices",
+			resultFileName: "storagecluster_storage_devices.yaml",
 			helmOption: &helm.Options{
-				ValuesFiles: []string{"./testValues/storagecluster_storage.yaml"},
+				ValuesFiles: []string{"./testValues/storagecluster_storage_devices.yaml"},
+			},
+		},
+		{
+			name:           "TestStorageSpecWithUseAll",
+			resultFileName: "storagecluster_storage_use_all.yaml",
+			helmOption: &helm.Options{
+				ValuesFiles: []string{"./testValues/storagecluster_storage_use_all.yaml"},
+			},
+		},
+		{
+			name:           "TestStorageSpecWithUseAll",
+			resultFileName: "storagecluster_storage_use_all.yaml",
+			helmOption: &helm.Options{
+				ValuesFiles: []string{"./testValues/storagecluster_storage_use_partitions.yaml"},
+			},
+		},
+		{
+			name:           "TestStorageSpecWithUsePartitions",
+			resultFileName: "storagecluster_storage_use_partitions.yaml",
+			helmOption: &helm.Options{
+				ValuesFiles: []string{"./testValues/storagecluster_storage_use_partitions.yaml"},
 			},
 		},
 	}
@@ -250,7 +277,7 @@ func TestStorageClusterHelmTemplate(t *testing.T) {
 			t.Parallel()
 			resultFilePath, err := filepath.Abs(filepath.Join("testspec/", testCase.resultFileName))
 			require.NoError(t, err)
-			test_utils.TestRenderedHelmTemplate(t, testCase.helmOption, helmChartPath, templateFileName, resultFilePath)
+			test_utils.TestRenderedHelmTemplate(t, testCase.helmOption, helmChartPath, templateFileName, resultFilePath, testCase.expectedErrorMsg)
 		})
 	}
 }

--- a/test/portworx/testValues/storagecluster_storage_devices.yaml
+++ b/test/portworx/testValues/storagecluster_storage_devices.yaml
@@ -4,4 +4,3 @@ journalDevice: "/dev/sdd"
 systemMetadataDevice: "/dev/sde"
 kvdbDevice: "/node-kvdb"
 cacheDevices: "/dev/one;/dev/two"
-usefileSystemDrive: true            

--- a/test/portworx/testValues/storagecluster_storage_use_all.yaml
+++ b/test/portworx/testValues/storagecluster_storage_use_all.yaml
@@ -1,0 +1,5 @@
+internalKVDB: true
+journalDevice: "/dev/sdd"
+systemMetadataDevice: "/dev/sde"
+kvdbDevice: "/node-kvdb"
+cacheDevices: "/dev/one;/dev/two"

--- a/test/portworx/testValues/storagecluster_storage_use_partitions.yaml
+++ b/test/portworx/testValues/storagecluster_storage_use_partitions.yaml
@@ -1,0 +1,7 @@
+internalKVDB: true
+journalDevice: "/dev/sdd"
+systemMetadataDevice: "/dev/sde"
+kvdbDevice: "/node-kvdb"
+cacheDevices: "/dev/one;/dev/two"
+usefileSystemDrive: false          
+usedrivesAndPartitions: false

--- a/test/portworx/testspec/storagecluster_all_compenents_enabled.yaml
+++ b/test/portworx/testspec/storagecluster_all_compenents_enabled.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     heritage: "Helm"
     release: "my-release"
-    chart: "portworx-3.1.0"
+    chart: "portworx-3.1.2"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "my-release"
 spec:

--- a/test/portworx/testspec/storagecluster_autopilot.yaml
+++ b/test/portworx/testspec/storagecluster_autopilot.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     heritage: "Helm"
     release: "my-release"
-    chart: "portworx-3.1.0"
+    chart: "portworx-3.1.2"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "my-release"
 spec:

--- a/test/portworx/testspec/storagecluster_cloudstorage.yaml
+++ b/test/portworx/testspec/storagecluster_cloudstorage.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     heritage: "Helm"
     release: "my-release"
-    chart: "portworx-3.1.0"
+    chart: "portworx-3.1.2"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "my-release"
 spec:

--- a/test/portworx/testspec/storagecluster_cloudstorage_aks.yaml
+++ b/test/portworx/testspec/storagecluster_cloudstorage_aks.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     heritage: "Helm"
     release: "my-release"
-    chart: "portworx-3.1.0"
+    chart: "portworx-3.1.2"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "my-release"
 spec:

--- a/test/portworx/testspec/storagecluster_csi_Snapshot_Controller_enabled.yaml
+++ b/test/portworx/testspec/storagecluster_csi_Snapshot_Controller_enabled.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     heritage: "Helm"
     release: "my-release"
-    chart: "portworx-3.1.0"
+    chart: "portworx-3.1.2"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "my-release"
 spec:

--- a/test/portworx/testspec/storagecluster_custom_metadata.yaml
+++ b/test/portworx/testspec/storagecluster_custom_metadata.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     heritage: "Helm"
     release: "my-release"
-    chart: "portworx-3.1.0"
+    chart: "portworx-3.1.2"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "my-release"
 spec:

--- a/test/portworx/testspec/storagecluster_custom_registry.yaml
+++ b/test/portworx/testspec/storagecluster_custom_registry.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     heritage: "Helm"
     release: "my-release"
-    chart: "portworx-3.1.0"
+    chart: "portworx-3.1.2"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "my-release"
 spec:

--- a/test/portworx/testspec/storagecluster_external_etcd.yaml
+++ b/test/portworx/testspec/storagecluster_external_etcd.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     heritage: "Helm"
     release: "my-release"
-    chart: "portworx-3.1.0"
+    chart: "portworx-3.1.2"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "my-release"
 spec:

--- a/test/portworx/testspec/storagecluster_featureGates.yaml
+++ b/test/portworx/testspec/storagecluster_featureGates.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     heritage: "Helm"
     release: "my-release"
-    chart: "portworx-3.1.0"
+    chart: "portworx-3.1.2"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "my-release"
 spec:

--- a/test/portworx/testspec/storagecluster_monitoring.yaml
+++ b/test/portworx/testspec/storagecluster_monitoring.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     heritage: "Helm"
     release: "my-release"
-    chart: "portworx-3.1.0"
+    chart: "portworx-3.1.2"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "my-release"
 spec:

--- a/test/portworx/testspec/storagecluster_monitoring_enable_by_enable_telemetry.yaml
+++ b/test/portworx/testspec/storagecluster_monitoring_enable_by_enable_telemetry.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     heritage: "Helm"
     release: "my-release"
-    chart: "portworx-3.1.0"
+    chart: "portworx-3.1.2"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "my-release"
 spec:

--- a/test/portworx/testspec/storagecluster_monitoring_enabled_exportmatrix.yaml
+++ b/test/portworx/testspec/storagecluster_monitoring_enabled_exportmatrix.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     heritage: "Helm"
     release: "my-release"
-    chart: "portworx-3.1.0"
+    chart: "portworx-3.1.2"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "my-release"
 spec:

--- a/test/portworx/testspec/storagecluster_nodeAffinity.yaml
+++ b/test/portworx/testspec/storagecluster_nodeAffinity.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     heritage: "Helm"
     release: "my-release"
-    chart: "portworx-3.1.0"
+    chart: "portworx-3.1.2"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "my-release"
 spec:

--- a/test/portworx/testspec/storagecluster_nodes_configuration.yaml
+++ b/test/portworx/testspec/storagecluster_nodes_configuration.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     heritage: "Helm"
     release: "my-release"
-    chart: "portworx-3.1.0"
+    chart: "portworx-3.1.2"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "my-release"
 spec:

--- a/test/portworx/testspec/storagecluster_placement.yaml
+++ b/test/portworx/testspec/storagecluster_placement.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     heritage: "Helm"
     release: "my-release"
-    chart: "portworx-3.1.0"
+    chart: "portworx-3.1.2"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "my-release"
 spec:

--- a/test/portworx/testspec/storagecluster_portworx_container_resources.yaml
+++ b/test/portworx/testspec/storagecluster_portworx_container_resources.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     heritage: "Helm"
     release: "my-release"
-    chart: "portworx-3.1.0"
+    chart: "portworx-3.1.2"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "my-release"
 spec:

--- a/test/portworx/testspec/storagecluster_runtimeOptions.yaml
+++ b/test/portworx/testspec/storagecluster_runtimeOptions.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     heritage: "Helm"
     release: "my-release"
-    chart: "portworx-3.1.0"
+    chart: "portworx-3.1.2"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "my-release"
 spec:

--- a/test/portworx/testspec/storagecluster_security_enabled.yaml
+++ b/test/portworx/testspec/storagecluster_security_enabled.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     heritage: "Helm"
     release: "my-release"
-    chart: "portworx-3.1.0"
+    chart: "portworx-3.1.2"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "my-release"
 spec:

--- a/test/portworx/testspec/storagecluster_storage_devices.yaml
+++ b/test/portworx/testspec/storagecluster_storage_devices.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     heritage: "Helm"
     release: "my-release"
-    chart: "portworx-3.1.0"
+    chart: "portworx-3.1.2"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "my-release"
 spec:
@@ -24,9 +24,7 @@ spec:
     cacheDevices:
         - /dev/one
         - /dev/two
-    forceUseDisks: true
     kvdbDevice: /node-kvdb
-    useAll: true
     systemMetadataDevice: /dev/sde
     journalDevice: /dev/sdd
   secretsProvider: k8s

--- a/test/portworx/testspec/storagecluster_storage_use_all.yaml
+++ b/test/portworx/testspec/storagecluster_storage_use_all.yaml
@@ -17,7 +17,13 @@ spec:
   kvdb:
     internal: true
   storage:
+    cacheDevices:
+        - /dev/one
+        - /dev/two
     useAll: true
+    kvdbDevice: /node-kvdb
+    systemMetadataDevice: /dev/sde
+    journalDevice: /dev/sdd
   secretsProvider: k8s
 
   env:
@@ -27,6 +33,4 @@ spec:
   stork:
     enabled: true
   csi:
-    enabled: true
-    topology:
-      enabled: true
+    enabled: false

--- a/test/portworx/testspec/storagecluster_storage_use_partitions.yaml
+++ b/test/portworx/testspec/storagecluster_storage_use_partitions.yaml
@@ -17,7 +17,13 @@ spec:
   kvdb:
     internal: true
   storage:
+    cacheDevices:
+        - /dev/one
+        - /dev/two
     useAll: true
+    kvdbDevice: /node-kvdb
+    systemMetadataDevice: /dev/sde
+    journalDevice: /dev/sdd
   secretsProvider: k8s
 
   env:
@@ -27,6 +33,4 @@ spec:
   stork:
     enabled: true
   csi:
-    enabled: true
-    topology:
-      enabled: true
+    enabled: false

--- a/test/portworx/testspec/storagecluster_stork.yaml
+++ b/test/portworx/testspec/storagecluster_stork.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     heritage: "Helm"
     release: "my-release"
-    chart: "portworx-3.1.0"
+    chart: "portworx-3.1.2"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "my-release"
 spec:

--- a/test/portworx/testspec/storagecluster_updatestrategy_invalid_type.yaml
+++ b/test/portworx/testspec/storagecluster_updatestrategy_invalid_type.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     heritage: "Helm"
     release: "my-release"
-    chart: "portworx-3.1.0"
+    chart: "portworx-3.1.2"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "my-release"
 spec:

--- a/test/portworx/testspec/storagecluster_updatestrategy_ondelete.yaml
+++ b/test/portworx/testspec/storagecluster_updatestrategy_ondelete.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     heritage: "Helm"
     release: "my-release"
-    chart: "portworx-3.1.0"
+    chart: "portworx-3.1.2"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "my-release"
 spec:

--- a/test/portworx/testspec/storagecluster_updatestrategy_rollingupdate.yaml
+++ b/test/portworx/testspec/storagecluster_updatestrategy_rollingupdate.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     heritage: "Helm"
     release: "my-release"
-    chart: "portworx-3.1.0"
+    chart: "portworx-3.1.2"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "my-release"
 spec:

--- a/test/portworx/testspec/storagecluster_volumes.yaml
+++ b/test/portworx/testspec/storagecluster_volumes.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     heritage: "Helm"
     release: "my-release"
-    chart: "portworx-3.1.0"
+    chart: "portworx-3.1.2"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "my-release"
 spec:

--- a/test/portworx/testspec/storagecluster_with_default_values.yaml
+++ b/test/portworx/testspec/storagecluster_with_default_values.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     heritage: "Helm"
     release: "my-release"
-    chart: "portworx-3.1.0"
+    chart: "portworx-3.1.2"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "my-release"
 spec:

--- a/test/utils/test_utils.go
+++ b/test/utils/test_utils.go
@@ -12,8 +12,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRenderedHelmTemplate(t *testing.T, helmOptions *helm.Options, helmChartPath string, renderTemplateFileName string, resultFilePath string) {
+func TestRenderedHelmTemplate(t *testing.T, helmOptions *helm.Options, helmChartPath string, renderTemplateFileName string, resultFilePath string, expectedErrorMsg string) {
 	t.Helper()
+
+	output, err := helm.RenderTemplateE(t, helmOptions, helmChartPath, "my-release", []string{fmt.Sprintf("templates/%v", renderTemplateFileName)})
+	if err != nil {
+		require.ErrorContains(t, err, expectedErrorMsg)
+		return
+	}
 
 	resultFileContent, err := os.ReadFile(resultFilePath)
 	if err != nil {
@@ -23,8 +29,6 @@ func TestRenderedHelmTemplate(t *testing.T, helmOptions *helm.Options, helmChart
 
 	var resultFileData interface{}
 	helm.UnmarshalK8SYaml(t, string(resultFileContent), &resultFileData)
-
-	output := helm.RenderTemplate(t, helmOptions, helmChartPath, "my-release", []string{fmt.Sprintf("templates/%v", renderTemplateFileName)})
 
 	var storageCluster interface{}
 	helm.UnmarshalK8SYaml(t, output, &storageCluster)


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
This PR resolves the issue of `useAll:true` being added when specifying local devices like `drives: /dev/sdb;/dev/sdc;/dev/sdd;/dev/sde`. Changes ensure that when `drives` are specified or `useDrivesAndPartitions:true` is set, `useAll` will not be included in the generated StorageCluster.
**Which issue(s) this PR fixes** (optional)

Closes #https://purestorage.atlassian.net/browse/PWX-38542

**Special notes for your reviewer**:
Testing Done