### PR TITLE
helm added variables for px-backup alert severity

### DIFF
--- a/charts/px-central/templates/px-backup/pxcentral-prometheus.yaml
+++ b/charts/px-central/templates/px-backup/pxcentral-prometheus.yaml
@@ -449,7 +449,7 @@ spec:
       expr: pxbackup_cluster_status == 5
       for: 1m
       labels:
-        severity: critical
+        severity: "{{ .Values.pxbackup.clusterAlert.severity }}"
 
     - alert: BackupAlert
       annotations:
@@ -459,7 +459,7 @@ spec:
       expr: pxbackup_backup_status == 4
       for: 1m
       labels:
-        severity: critical
+        severity: "{{ .Values.pxbackup.backupAlert.severity }}"
 
     - alert: RestoreAlert
       annotations:
@@ -469,7 +469,7 @@ spec:
       expr: pxbackup_restore_status == 4
       for: 1m
       labels:
-        severity: critical
+        severity: "{{ .Values.pxbackup.restoreAlert.severity }}"
 
     - alert: BackupLocationAlert
       annotations:
@@ -479,4 +479,4 @@ spec:
       expr: pxbackup_backup_location_status == 4
       for: 1m
       labels:
-        severity: critical
+        severity: "{{ .Values.pxbackup.backupLocationAlert.severity }}"

--- a/charts/px-central/templates/px-backup/pxcentral-prometheus.yaml
+++ b/charts/px-central/templates/px-backup/pxcentral-prometheus.yaml
@@ -449,7 +449,7 @@ spec:
       expr: pxbackup_cluster_status == 5
       for: 1m
       labels:
-        severity: "{{ .Values.pxbackup.clusterAlert.severity }}"
+        severity: "{{ .Values.pxbackup.alertSeverity.clusterAlert }}"
 
     - alert: BackupAlert
       annotations:
@@ -459,7 +459,7 @@ spec:
       expr: pxbackup_backup_status == 4
       for: 1m
       labels:
-        severity: "{{ .Values.pxbackup.backupAlert.severity }}"
+        severity: "{{ .Values.pxbackup.alertSeverity.backupAlert }}"
 
     - alert: RestoreAlert
       annotations:
@@ -469,7 +469,7 @@ spec:
       expr: pxbackup_restore_status == 4
       for: 1m
       labels:
-        severity: "{{ .Values.pxbackup.restoreAlert.severity }}"
+        severity: "{{ .Values.pxbackup.alertSeverity.restoreAlert }}"
 
     - alert: BackupLocationAlert
       annotations:
@@ -479,4 +479,4 @@ spec:
       expr: pxbackup_backup_location_status == 4
       for: 1m
       labels:
-        severity: "{{ .Values.pxbackup.backupLocationAlert.severity }}"
+        severity: "{{ .Values.pxbackup.alertSeverity.backupLocationAlert }}"

--- a/charts/px-central/values.yaml
+++ b/charts/px-central/values.yaml
@@ -67,6 +67,11 @@ pxbackup:
   prometheusSecretName: ""
   alertmanagerSecretName: ""
   usePxBackupEmailAlertTemplate: true
+  alertSeverity:
+    clusterAlert: critical
+    backupAlert: critical
+    restoreAlert: critical
+    backupLocationAlert: critical
 
 pxlicenseserver:
   enabled: false


### PR DESCRIPTION
**What this PR does / why we need it**:
Let us change the severity of the px-backup alerts.

