### PR TITLE
PB-7469 | Moving hard-coded API_TIMEOUT value for UI to config-map

### DIFF
--- a/charts/px-central/templates/px-lighthouse/px-central-ui/pxcentral-ui-configmap.yaml
+++ b/charts/px-central/templates/px-lighthouse/px-central-ui/pxcentral-ui-configmap.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/component: pxcentral-frontend
 {{- include "px-central.labels" . | nindent 4 }}
 data:
+  API_TIMEOUT: "90"
   APP_KEY: base64:J1RH3W4+CILq3/eac9zqYbAMzeptqCJgR9KcWRdhtHw=
   BASE_ROOT_PATH: /
   DB_PORT: "3306"


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Moving the hard-coded API_TIMEOUT value for UI to config-map

**Which issue(s) this PR fixes** (optional)
Closes # PB-7469

**Special notes for your reviewer**:
Tested from UI that the config map value is correctly picked up.


