### PR TITLE
PWX-39141 | Changed default namespace to Portworx

### DIFF
--- a/charts/portworx/templates/_helpers.tpl
+++ b/charts/portworx/templates/_helpers.tpl
@@ -224,7 +224,7 @@ Generate a random token for storage provisioning
 {{- define "px.getDeploymentNamespace" -}}
 {{- if (.Release.Namespace) -}}
     {{- if (eq "default" .Release.Namespace) -}}
-        {{- printf "kube-system"  -}}
+        {{- printf "portworx"  -}}
     {{- else -}}
         {{- printf "%s" .Release.Namespace -}}
     {{- end -}}

--- a/charts/portworx/templates/portworx-k8s-secrets.yaml
+++ b/charts/portworx/templates/portworx-k8s-secrets.yaml
@@ -1,8 +1,14 @@
 {{- $secretType := .Values.secretType | default "k8s" }}
 
 {{- if eq $secretType "k8s" }}
+{{- $namespace := "portworx" }}
+{{- $existingNamespace := lookup "v1" "Namespace" "" $namespace }}
+
+{{- if not $existingNamespace }}
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: portworx
+  name: {{ $namespace }}
 {{- end -}}
+{{- end -}}
+


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
This PR will changed default namespace to portworx from kube-system
**Which issue(s) this PR fixes** (optional)
Closes #https://purestorage.atlassian.net/browse/PWX-39414

**Special notes for your reviewer**:

