### PR TITLE
Fixes #664 - Support Multi instances of px-central - multi Helm releases

### DIFF
--- a/charts/px-central/Chart.yaml
+++ b/charts/px-central/Chart.yaml
@@ -13,6 +13,6 @@ keywords:
 name: px-central
 sources:
 - https://github.com/portworx/helm/tree/master/charts/px-central
-version: 2.7.3
+version: 2.7.4
 appVersion: 2.7.3
 name: px-central

--- a/charts/px-central/templates/px-backup/pxcentral-backup.yaml
+++ b/charts/px-central/templates/px-backup/pxcentral-backup.yaml
@@ -16,8 +16,7 @@ metadata:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: px-backup-cluster-role
-  namespace: {{ .Release.Namespace }}
+  name: px-backup-cluster-role-{{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: px-backup
 {{- include "px-central.labels" . | nindent 4 }}
@@ -46,8 +45,7 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: px-backup-cluster-role-binding
-  namespace: {{ .Release.Namespace }}
+  name: px-backup-cluster-role-binding-{{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: pxcentral-apiserver
 {{- include "px-central.labels" . | nindent 4 }}
@@ -57,7 +55,7 @@ subjects:
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: px-backup-cluster-role
+  name: px-backup-cluster-role-{{ .Release.Namespace }}
   apiGroup: rbac.authorization.k8s.io
 ---
 kind: Role

--- a/charts/px-central/templates/px-backup/pxcentral-prometheus.yaml
+++ b/charts/px-central/templates/px-backup/pxcentral-prometheus.yaml
@@ -28,8 +28,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: pxc-prometheus-operator
-  namespace: {{ .Release.Namespace }}
+  name: pxc-prometheus-operator-{{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: px-backup
 {{- include "px-central.labels" . | nindent 4 }}
@@ -40,13 +39,12 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: pxc-prometheus-operator
+  name: pxc-prometheus-operator-{{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: pxc-prometheus-operator
-  namespace: {{ .Release.Namespace }}
+  name: pxc-prometheus-operator-{{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: px-backup
 {{- include "px-central.labels" . | nindent 4 }}
@@ -187,8 +185,7 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: px-backup-dashboard-prometheus
-  namespace: {{ .Release.Namespace }}
+  name: px-backup-dashboard-prometheus-{{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: px-backup
 {{- include "px-central.labels" . | nindent 4 }}
@@ -219,15 +216,14 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: px-backup-dashboard-prometheus
-  namespace: {{ .Release.Namespace }}
+  name: px-backup-dashboard-prometheus-{{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: px-backup
 {{- include "px-central.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: px-backup-dashboard-prometheus
+  name: px-backup-dashboard-prometheus-{{ .Release.Namespace }}
 subjects:
 - kind: ServiceAccount
   name: px-backup-dashboard-prometheus

--- a/charts/px-central/templates/px-lighthouse/pxcentral-api-server.yaml
+++ b/charts/px-central/templates/px-lighthouse/pxcentral-api-server.yaml
@@ -43,8 +43,7 @@ roleRef:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Release.Name | quote }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ .Release.Name | quote }}-{{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: pxcentral-apiserver
 {{- include "px-central.labels" . | nindent 4 }}
@@ -59,7 +58,7 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Release.Name | quote }}
+  name: {{ .Release.Name | quote }}-{{ .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: pxcentral-apiserver
@@ -70,7 +69,7 @@ subjects:
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: {{ .Release.Name | quote }}
+  name: {{ .Release.Name | quote }}-{{ .Release.Namespace }}
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: v1

--- a/charts/px-central/templates/px-lighthouse/pxcentral-api-server.yaml
+++ b/charts/px-central/templates/px-lighthouse/pxcentral-api-server.yaml
@@ -59,7 +59,6 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Name | quote }}-{{ .Release.Namespace }}
-  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: pxcentral-apiserver
 {{- include "px-central.labels" . | nindent 4 }}

--- a/charts/px-central/templates/px-monitor/prometheus/prometheus.yaml
+++ b/charts/px-central/templates/px-monitor/prometheus/prometheus.yaml
@@ -27,8 +27,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: pxcentral-prometheus
-  namespace: {{ .Release.Namespace }}
+  name: pxcentral-prometheus-{{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: pxcentral-prometheus
 {{- include "px-central.labels" . | nindent 4 }}
@@ -50,15 +49,14 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: pxcentral-prometheus
-  namespace: {{ .Release.Namespace }}
+  name: pxcentral-prometheus-{{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: pxcentral-prometheus
 {{- include "px-central.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: pxcentral-prometheus
+  name: pxcentral-prometheus-{{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
     name: pxcentral-prometheus
@@ -207,8 +205,7 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: pxcentral-prometheus-operator
-  namespace: {{ .Release.Namespace }}
+  name: pxcentral-prometheus-operator-{{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: pxcentral-prometheus
 {{- include "px-central.labels" . | nindent 4 }}
@@ -269,15 +266,14 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: pxcentral-prometheus-operator
-  namespace: {{ .Release.Namespace }}
+  name: pxcentral-prometheus-operator-{{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: pxcentral-prometheus
 {{- include "px-central.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: pxcentral-prometheus-operator
+  name: pxcentral-prometheus-operator-{{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
     name: pxcentral-prometheus-operator


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
it's suffixing all cluster-wide resources ( clusterrole and clusterrolebinding) with `{{.Release.Namespace}}` , so px-central can be deployed many times in the same cluster within different namespaces.


**Which issue(s) this PR fixes** (optional)
Closes #664

**Special notes for your reviewer**:
N/A


