### PR TITLE
pb-8928: added check for isBackupReady_for_PXDLocalSnapshotRestore flag from backup object json

### DIFF
--- a/charts/px-central/local_snapshot_restore.py
+++ b/charts/px-central/local_snapshot_restore.py
@@ -290,6 +290,14 @@ def restore_volume(volume_name, snapshot_id):
 # --------------------------------------------------------------------------------
 # Main logic
 # --------------------------------------------------------------------------------
+def check_backup_ready(data):
+    """
+    Check if the JSON file has isBackupReady_for_PXDLocalSnapshotRestore set to True.
+    """
+    backup_ready = data.get("backup_info", {}).get("isBackupReady_for_PXDLocalSnapshotRestore")
+    if backup_ready is not True:
+        logger.error("Localsnapshot restore is not possible as isBackupReady_for_PXDLocalSnapshotRestore is not set to True in the given backup json file.")
+        sys.exit(1)
 
 def process_volume(volume_obj):
     """
@@ -380,6 +388,8 @@ def main(input_file):
     if not isinstance(data, dict):
         logger.error("Top-level JSON is not a dictionary.")
         return 1
+    # Check if the backup is ready
+    check_backup_ready(data)
 
     backup_info = data.get("backup_info", {})
     if not isinstance(backup_info, dict):
@@ -496,4 +506,3 @@ if __name__ == "__main__":
     input_file = sys.argv[1]
     exit_code = main(input_file)
     sys.exit(exit_code)
-


### PR DESCRIPTION

**What this PR does / why we need it**:
```
pb-8928: added check for isBackupReady_for_PXDLocalSnapshotRestore flag from backup object json
```
**Which issue(s) this PR fixes** (optional)
Closes # pb-8928

**Special notes for your reviewer**:
Test result:
```
[core@pwx-ocp-0-167-9wcvn-worker-0-8xfxw ~]$ python3 ./test.py backup.json
2025-01-27 13:46:56,398 - ERROR - Localsnapshot restore is not possible as isBackupReady_for_PXDLocalSnapshotRestore is not set to True in the given backup json file.
[core@pwx-ocp-0-167-9wcvn-worker-0-8xfxw ~]$ vi backup.json
[core@pwx-ocp-0-167-9wcvn-worker-0-8xfxw ~]$ python3 ./test.py backup.json
+-------+-----------+------------+------------------------------------------+--------------------+
| Index | Namespace | PVC        | Name                                     | SnapshotID         |
+-------+-----------+------------+------------------------------------------+--------------------+
| 0     | mysql1    | mysql-data | pvc-eaaca07f-3a5d-447d-830e-ec51f1a3fb2f | 846700369117162754 |
+-------+-----------+------------+------------------------------------------+--------------------+

Enter indexes to restore (comma-separated), or type 'all' to restore all volumes:
>
```
