### PR TITLE
Add mongodb5 to versions list

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -16,6 +16,7 @@ modules:
     pxBackup: "docker.io/portworx/px-backup:2.8.3_EA"
     mongodb: "docker.io/portworx/mongodb:7.0.15-debian-12-r2"
     mongodb6: "docker.io/portworx/mongodb:6.0.13-debian-11-r21"
+    mongodb5: "docker.io/portworx/mongodb:5.0.24-debian-11-r20"
     kopiaExecutor: "docker.io/portworx/kopiaexecutor:1.2.17"
     nfsExecutor: "docker.io/portworx/nfsexecutor:1.2.17"
     filesystemCtl: "docker.io/portworx/filesystemctl:1.2.17"


### PR DESCRIPTION
mongodb5 image was not present in versions.yaml but is used in values.yaml, hence, air-gapped upgrade was failing.