### PR TITLE
Allow overriding portworx target namespace

### DIFF
--- a/charts/portworx/templates/_helpers.tpl
+++ b/charts/portworx/templates/_helpers.tpl
@@ -222,12 +222,12 @@ Generate a random token for storage provisioning
 
 
 {{- define "px.getDeploymentNamespace" -}}
-{{- if (.Release.Namespace) -}}
-    {{- if (eq "default" .Release.Namespace) -}}
-        {{- printf "portworx"  -}}
-    {{- else -}}
-        {{- if (.Values.namespaceOverride) -}}
-            {{- printf "%s" .Values.namespaceOverride -}}
+{{- if not .Values.namespaceOverride | empty -}}
+    {{- printf "%s" .Values.namespaceOverride -}}
+{{- else -}}
+    {{- if (.Release.Namespace) -}}
+        {{- if (eq "default" .Release.Namespace) -}}
+            {{- printf "portworx"  -}}
         {{- else -}}
             {{- printf "%s" .Release.Namespace -}}
         {{- end -}}

--- a/charts/portworx/templates/_helpers.tpl
+++ b/charts/portworx/templates/_helpers.tpl
@@ -226,7 +226,11 @@ Generate a random token for storage provisioning
     {{- if (eq "default" .Release.Namespace) -}}
         {{- printf "portworx"  -}}
     {{- else -}}
-        {{- printf "%s" .Release.Namespace -}}
+        {{- if (.Values.namespaceOverride) -}}
+            {{- printf "%s" .Values.namespaceOverride -}}
+        {{- else -}}
+            {{- printf "%s" .Release.Namespace -}}
+        {{- end -}}
     {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/portworx/templates/portworx-k8s-secrets.yaml
+++ b/charts/portworx/templates/portworx-k8s-secrets.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq .Release.Namespace "default") (not (lookup "v1" "Namespace" "portworx" "portworx")) }}
+{{- if or (and (eq .Release.Namespace "default") (not (lookup "v1" "Namespace" "portworx" "portworx"))) (not .Values.namespaceOverride | empty)}}
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/charts/portworx/values.yaml
+++ b/charts/portworx/values.yaml
@@ -3,6 +3,8 @@
 deployOperator: true                    # Deploy the Portworx operator
 deployCluster: true                     # Deploy the Portworx cluster
 
+namespaceOverride: ~                   # Override the namespace the chart deploys to
+
 imageVersion: 3.2.2                    # Version of the PX Image.
 pxOperatorImageVersion: 24.2.3         # Version of the PX operator image.
 

--- a/test/portworx/storagecluster_helm_template_test.go
+++ b/test/portworx/storagecluster_helm_template_test.go
@@ -54,6 +54,13 @@ func TestStorageClusterHelmTemplate(t *testing.T) {
 			},
 		},
 		{
+			name:           "TestOverrideNamespace",
+			resultFileName: "storagecluster_override_namespace.yaml",
+			helmOption: &helm.Options{
+				ValuesFiles: []string{"./testValues/storagecluster_override_namespace.yaml"},
+			},
+		},
+		{
 			name:           "TestExternalETCD",
 			resultFileName: "storagecluster_external_etcd.yaml",
 			helmOption: &helm.Options{

--- a/test/portworx/testValues/storagecluster_override_namespace.yaml
+++ b/test/portworx/testValues/storagecluster_override_namespace.yaml
@@ -1,0 +1,1 @@
+namespaceOverride: custom-namespace

--- a/test/portworx/testspec/storagecluster_override_namespace.yaml
+++ b/test/portworx/testspec/storagecluster_override_namespace.yaml
@@ -1,0 +1,30 @@
+kind: StorageCluster
+apiVersion: core.libopenstorage.org/v1
+metadata:
+  name: "mycluster"
+  namespace: custom-namespace
+  annotations:
+  labels:
+    heritage: "Helm"
+    release: "my-release"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "my-release"
+spec:
+  image: portworx/oci-monitor:3.2.1.1
+  imagePullPolicy: Always
+
+  kvdb:
+    internal: true
+  storage:
+    useAll: true
+  secretsProvider: k8s
+  
+  stork:
+    enabled: true
+  monitoring:
+    telemetry:
+      enabled: true
+  csi:
+    enabled: true
+  autopilot:
+    enabled: true


### PR DESCRIPTION
Make sure to have done the following:
  - [X] Signed off your work as per the DCO.
  - [X] Add unit-tests

**What this PR does / why we need it**:
This PR adds a new `namespaceOverride` value to the Portworx chart so that user can easily override the target Portworx install namespace.

**Which issue(s) this PR fixes** (optional)
#728 

**Special notes for your reviewer**:
My specific unit-test is passing but diffs are reported around image tags which I believe are  not related to my changes : 

```
root@f21272600cc8:/app/test/portworx# go test -run TestStorageClusterHelmTemplate/TestOverrideNamespace
TestStorageClusterHelmTemplate/TestOverrideNamespace 2025-03-27T10:23:43Z logger.go:66: Running command helm with args [template -f /app/test/portworx/testValues/storagecluster_override_namespace.yaml --show-only templates/storage-cluster.yaml my-release /app/charts/portworx]
TestStorageClusterHelmTemplate/TestOverrideNamespace 2025-03-27T10:23:43Z logger.go:66: ---
TestStorageClusterHelmTemplate/TestOverrideNamespace 2025-03-27T10:23:43Z logger.go:66: # Source: portworx/templates/storage-cluster.yaml
TestStorageClusterHelmTemplate/TestOverrideNamespace 2025-03-27T10:23:43Z logger.go:66: kind: StorageCluster
TestStorageClusterHelmTemplate/TestOverrideNamespace 2025-03-27T10:23:43Z logger.go:66: apiVersion: core.libopenstorage.org/v1
TestStorageClusterHelmTemplate/TestOverrideNamespace 2025-03-27T10:23:43Z logger.go:66: metadata:
TestStorageClusterHelmTemplate/TestOverrideNamespace 2025-03-27T10:23:43Z logger.go:66:   name: "mycluster"
TestStorageClusterHelmTemplate/TestOverrideNamespace 2025-03-27T10:23:43Z logger.go:66:   namespace: custom-namespace
TestStorageClusterHelmTemplate/TestOverrideNamespace 2025-03-27T10:23:43Z logger.go:66:   annotations:
TestStorageClusterHelmTemplate/TestOverrideNamespace 2025-03-27T10:23:43Z logger.go:66:   labels:
TestStorageClusterHelmTemplate/TestOverrideNamespace 2025-03-27T10:23:43Z logger.go:66:     heritage: "Helm"
TestStorageClusterHelmTemplate/TestOverrideNamespace 2025-03-27T10:23:43Z logger.go:66:     release: "my-release"
TestStorageClusterHelmTemplate/TestOverrideNamespace 2025-03-27T10:23:43Z logger.go:66:     chart: "portworx-5.1.3"
TestStorageClusterHelmTemplate/TestOverrideNamespace 2025-03-27T10:23:43Z logger.go:66:     app.kubernetes.io/managed-by: "Helm"
TestStorageClusterHelmTemplate/TestOverrideNamespace 2025-03-27T10:23:43Z logger.go:66:     app.kubernetes.io/instance: "my-release"
TestStorageClusterHelmTemplate/TestOverrideNamespace 2025-03-27T10:23:43Z logger.go:66: spec:
TestStorageClusterHelmTemplate/TestOverrideNamespace 2025-03-27T10:23:43Z logger.go:66:   image: portworx/oci-monitor:3.2.2
TestStorageClusterHelmTemplate/TestOverrideNamespace 2025-03-27T10:23:43Z logger.go:66:   imagePullPolicy: Always
TestStorageClusterHelmTemplate/TestOverrideNamespace 2025-03-27T10:23:43Z logger.go:66:
TestStorageClusterHelmTemplate/TestOverrideNamespace 2025-03-27T10:23:43Z logger.go:66:   kvdb:
TestStorageClusterHelmTemplate/TestOverrideNamespace 2025-03-27T10:23:43Z logger.go:66:     internal: true
TestStorageClusterHelmTemplate/TestOverrideNamespace 2025-03-27T10:23:43Z logger.go:66:   storage:
TestStorageClusterHelmTemplate/TestOverrideNamespace 2025-03-27T10:23:43Z logger.go:66:     useAll: true
TestStorageClusterHelmTemplate/TestOverrideNamespace 2025-03-27T10:23:43Z logger.go:66:   secretsProvider: k8s
TestStorageClusterHelmTemplate/TestOverrideNamespace 2025-03-27T10:23:43Z logger.go:66:
TestStorageClusterHelmTemplate/TestOverrideNamespace 2025-03-27T10:23:43Z logger.go:66:   stork:
TestStorageClusterHelmTemplate/TestOverrideNamespace 2025-03-27T10:23:43Z logger.go:66:     enabled: true
TestStorageClusterHelmTemplate/TestOverrideNamespace 2025-03-27T10:23:43Z logger.go:66:   monitoring:
TestStorageClusterHelmTemplate/TestOverrideNamespace 2025-03-27T10:23:43Z logger.go:66:     telemetry:
TestStorageClusterHelmTemplate/TestOverrideNamespace 2025-03-27T10:23:43Z logger.go:66:       enabled: true
TestStorageClusterHelmTemplate/TestOverrideNamespace 2025-03-27T10:23:43Z logger.go:66:   csi:
TestStorageClusterHelmTemplate/TestOverrideNamespace 2025-03-27T10:23:43Z logger.go:66:     enabled: true
TestStorageClusterHelmTemplate/TestOverrideNamespace 2025-03-27T10:23:43Z logger.go:66:   autopilot:
TestStorageClusterHelmTemplate/TestOverrideNamespace 2025-03-27T10:23:43Z logger.go:66:     enabled: true
Differences found:
  map[string]any{
        "apiVersion": string("core.libopenstorage.org/v1"),
        "kind":       string("StorageCluster"),
        "metadata":   map[string]any{"annotations": nil, "labels": map[string]any{"app.kubernetes.io/instance": string("my-release"), "app.kubernetes.io/managed-by": string("Helm"), "heritage": string("Helm"), "release": string("my-release")}, "name": string("mycluster"), "namespace": string("custom-namespace")},
        "spec": map[string]any{
                "autopilot":       map[string]any{"enabled": bool(true)},
                "csi":             map[string]any{"enabled": bool(true)},
-               "image":           string("portworx/oci-monitor:3.2.1.1"),
+               "image":           string("portworx/oci-monitor:3.2.2"),
                "imagePullPolicy": string("Always"),
                "kvdb":            map[string]any{"internal": bool(true)},
                ... // 4 identical entries
        },
  }
--- FAIL: TestStorageClusterHelmTemplate (0.00s)
    --- FAIL: TestStorageClusterHelmTemplate/TestOverrideNamespace (0.07s)
        storagecluster_helm_template_test.go:323:
                Error Trace:    /app/test/utils/test_utils.go:36
                Error:          Not equal:
                                expected: false
                                actual  : true
                Test:           TestStorageClusterHelmTemplate/TestOverrideNamespace
FAIL
exit status 1
FAIL    github.com/portworx/helm/test/portworx  0.080s
```

Antoine