### PR TITLE
Removing datastoreEndpoints param from px-backup deployment spec

### DIFF
--- a/charts/px-central/templates/px-backup/pxcentral-backup.yaml
+++ b/charts/px-central/templates/px-backup/pxcentral-backup.yaml
@@ -278,7 +278,7 @@ spec:
         command: ["/bin/bash", "-c"]
         args:
           - >
-            /px-backup start --datastoreEndpoints="mongodb://$MONGODB_USERNAME:$MONGODB_PASSWORD@pxc-backup-mongodb-0.pxc-backup-mongodb-headless:27017,pxc-backup-mongodb-1.pxc-backup-mongodb-headless:27017,pxc-backup-mongodb-2.pxc-backup-mongodb-headless:27017/?authSource=px-backup&replicaSet=rs0" --mongo-migration={{.Values.pxbackup.mongoMigration}}
+            /px-backup start --mongo-migration={{.Values.pxbackup.mongoMigration}}
       {{- if .Values.caCertsSecretName }}
       volumes:
         - name: ssl-cert-dir


### PR DESCRIPTION
Removing datastoreEndpoints param from px-backup deployment spec

**What this PR does / why we need it**:
This is needed for password customisation. We are now allowing customer to provide the password and in order to escape special characters we are constructing the datastore endpoint (which is nothing but the mongodb URI) in px-backup instead of passing it as a parameter in the spec.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

