### PR TITLE
PWX-43196 | PWX-43220 | Add imagePullSecret in operator deployment and Fix security context issue

### DIFF
--- a/charts/portworx/templates/portworx-operator.yaml
+++ b/charts/portworx/templates/portworx-operator.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.deployOperator }}
+{{- $registrySecret := .Values.registrySecret | default "none" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -100,4 +101,8 @@ spec:
                       - portworx-operator
               topologyKey: "kubernetes.io/hostname"
       serviceAccountName: portworx-operator
+      {{- if not (eq $registrySecret "none") }}
+      imagePullSecrets: 
+      - name: {{ $registrySecret }}
+      {{- end }}
 {{- end }}

--- a/charts/portworx/templates/storage-cluster.yaml
+++ b/charts/portworx/templates/storage-cluster.yaml
@@ -466,10 +466,10 @@ spec:
       volumeMounts:
           {{- toYaml . | nindent 6  }}
       {{- end}}
-      {{- if $prometheus.securityContext.runAsNonRoot }}
+      {{- with $prometheus.securityContext }}
       securityContext:
-        runAsNonRoot: true
-      {{- end}}
+        {{- toYaml . | nindent 8  }}
+      {{- end }}
     {{- end }}
 
     {{- if .Values.monitoring.telemetry }}

--- a/charts/portworx/values.yaml
+++ b/charts/portworx/values.yaml
@@ -138,8 +138,10 @@ monitoring:
     volumeMounts:                     # Additional VolumeMounts for the Prometheus StatefulSet
     # - mountPath: /test
     #   name: additional-volume
-    securityContext:                  # Enable prometheus container run as a non-root user.
-      runAsNonRoot: false
+    securityContext:                  # Enable prometheus container run as a non-root user. 
+    # Provide securityContext fields as defined by Kubernetes (https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
+      # runAsNonRoot: false
+      # runAsUser: 1000
   telemetry: true                    # Enable telemetry
   grafana: false                      # Enable grafana
 

--- a/test/portworx/testValues/storagecluster_monitoring.yaml
+++ b/test/portworx/testValues/storagecluster_monitoring.yaml
@@ -29,6 +29,9 @@ monitoring:
       - mountPath: /data/prometheus
         name: additional-volume
     securityContext:
-      runAsNonRoot: false
+      runAsNonRoot: true
+      runAsUser: 1000
+      seLinuxOptions:
+        level: "s0:c123,c456"
   telemetry: true
   grafana: true

--- a/test/portworx/testspec/storagecluster_monitoring.yaml
+++ b/test/portworx/testspec/storagecluster_monitoring.yaml
@@ -30,6 +30,11 @@ spec:
       replicas: 5
       retention: 24h
       retentionSize: 10GiB
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        seLinuxOptions:
+          level: "s0:c123,c456"
       resources:
         limits:
           cpu: 500m


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
This PR adds support for specifying `imagePullSecrets` in the Portworx Operator deployment, which is necessary when pulling images from private registries.

It also fixes an issue where the Prometheus pod failed to start when `securityContext.runAsNonRoot` was set to true in `values.yaml`. Previously, the chart only allowed setting `runAsNonRoot`, but didn't provide a way to specify other necessary fields like `runAsUser`. This caused the Prometheus pod to crash due to insufficient security context configuration.

With this fix, users can now define a full `securityContext` block in `values.yaml`, including `runAsUser` and other relevant fields, ensuring that Prometheus starts successfully when running as a non-root user.

**Which issue(s) this PR fixes** (optional)
Closes # [PWX-43196](https://purestorage.atlassian.net/browse/PWX-43196) and [PWX-43220](https://purestorage.atlassian.net/browse/PWX-43220)

**Special notes for your reviewer**:




[PWX-43196]: https://purestorage.atlassian.net/browse/PWX-43196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PWX-43220]: https://purestorage.atlassian.net/browse/PWX-43220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ