### PR TITLE
PB-3481: Fix MongoDB replica set stability by waiting for DNS and enforcing consistent replica set join logic

### DIFF
--- a/charts/px-central/templates/px-backup/pxcentral-mongodb.yaml
+++ b/charts/px-central/templates/px-backup/pxcentral-mongodb.yaml
@@ -25,6 +25,15 @@ data:
     echo "Advertised Hostname: $MONGODB_ADVERTISED_HOSTNAME"
     echo "Advertised Service: $K8S_SERVICE_NAME"
 
+    # Wait until all peers are resolvable via DNS
+    for i in 0 1 2; do
+      host="pxc-backup-mongodb-$i.pxc-backup-mongodb-headless"
+      echo "Waiting for DNS resolution of $host..."
+      until getent hosts $host > /dev/null; do
+        sleep 3
+      done
+    done
+
     # Check for existing replica set in case there is no data in the PVC
     # This is for cases where the PVC is lost or for MongoDB caches without
     # persistence
@@ -39,7 +48,8 @@ data:
       {{- $mongoList = append $mongoList (printf "%s-%d.%s-headless:%d" $fullname $i $fullname $portNumber) }}
       {{- end }}
       echo "mongoList: {{ join "," $mongoList }}"
-      current_primary=$(mongosh admin --host "{{ join "," $mongoList }}" --authenticationDatabase admin -u root -p $MONGODB_ROOT_PASSWORD --eval 'db.runCommand("ismaster")' | awk -F\' '/primary/ {print $2}')
+    current_primary=$(mongosh admin --host "$mongoList" --authenticationDatabase admin -u root -p "$MONGODB_ROOT_PASSWORD" \
+    --eval 'try { isMaster = db.runCommand("ismaster"); print(isMaster.primary); } catch (e) { print(""); }' | tail -n 1)
 
       if ! is_empty_value "$current_primary"; then
         echo "Detected existing primary: ${current_primary}"
@@ -59,9 +69,10 @@ data:
         echo "Pod name matches initial primary pod name, configuring node as a primary"
         export MONGODB_REPLICA_SET_MODE="primary"
     else
-        echo "Pod name doesn't match initial primary pod name, configuring node as a secondary"
-        export MONGODB_REPLICA_SET_MODE="secondary"
-        export MONGODB_INITIAL_PRIMARY_PORT_NUMBER="$MONGODB_PORT_NUMBER"
+      export MONGODB_REPLICA_SET_MODE="secondary"
+      export MONGODB_INITIAL_PRIMARY_HOST="pxc-backup-mongodb-0.pxc-backup-mongodb-headless"
+      export MONGODB_INITIAL_PRIMARY_PORT_NUMBER="$MONGODB_PORT_NUMBER"
+      export MONGODB_SET_SECONDARY_OK="yes"
     fi
 
     if [[ "$MONGODB_REPLICA_SET_MODE" == "secondary" ]]; then


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [x] Signed off your work as per the DCO.
  [ ] Add unit-tests
-->

**What this PR does / why we need it**:

This PR improves the resilience of MongoDB replica set initialization and joining in the PX-Backup Helm deployment. It addresses issues where deleting MongoDB pods one-by-one could cause the primary to become non-writable (`isWritablePrimary: false`) due to DNS propagation delays or replica set misconfiguration.

Key improvements:
- Adds a DNS wait loop to ensure all replica set peers are resolvable before MongoDB starts.
- Updates `setup.sh` to prevent secondaries from initiating a new replica set by mistake.
- Explicitly sets `MONGODB_INITIAL_PRIMARY_HOST` for all secondary pods to join `pod-0`.
- Ensures fallback conditions for clean PVC or startup cases still lead to proper replica set joining.
- Improves logging and diagnostic clarity to help with debugging future upgrade issues.

This change improves upgrade stability, reduces flakiness in integration tests, and prevents unwanted replica set splits or non-writable states that crash the PX-Backup pod.

**Which issue(s) this PR fixes** (optional)  
Closes # (internal or external tracking ID, if any)

BYOC 
1. https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/13250/
2. https://jenkins.pwx.dev.purestorage.com/job/portworx-backup/job/system-tests/job/byoc/job/px-backup-on-demand-system-test-byoc/13252/

<img width="1728" alt="Screenshot 2025-06-01 at 9 36 24 PM" src="https://github.com/user-attachments/assets/6c82d224-5fa1-459b-aca4-f66860329185" />
<img width="1728" alt="Screenshot 2025-06-01 at 9 38 19 PM" src="https://github.com/user-attachments/assets/735ec4ca-b5fd-43b2-9e22-7106c86e7e9f" />
<img width="1132" alt="Screenshot 2025-06-01 at 9 38 31 PM" src="https://github.com/user-attachments/assets/f2e08ab2-c80f-4811-a513-dbd26e33828b" />



