### PR TITLE
PB-11135: Added global parameter for setting repo and registry to all the images

### DIFF
--- a/charts/px-central/templates/px-backup/pre-install-hook/pre-install-check.yaml
+++ b/charts/px-central/templates/px-backup/pre-install-hook/pre-install-check.yaml
@@ -157,7 +157,7 @@ spec:
               {{- end }}
       containers:
         - name: pxbackup-pre-install-check
-          image: {{ printf "%s/%s/%s:%s" .Values.images.preSetupHookImage.registry .Values.images.preSetupHookImage.repo .Values.images.preSetupHookImage.imageName .Values.images.preSetupHookImage.tag }}
+          image: {{ printf "%s/%s/%s:%s" (default .Values.images.preSetupHookImage.registry .Values.images.registry) (default .Values.images.preSetupHookImage.repo .Values.images.repo) .Values.images.preSetupHookImage.imageName .Values.images.preSetupHookImage.tag }}
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           command: ["/pxcentral-hook/bin/pxcentral-hook"]
           args: ["--hook=pre-install"]
@@ -277,7 +277,7 @@ spec:
               {{- end }}
       containers:
         - name: pxbackup-pre-flight-checker
-          image: {{ printf "%s/%s/%s:%s" .Values.images.preSetupHookImage.registry .Values.images.preSetupHookImage.repo .Values.images.preSetupHookImage.imageName .Values.images.preSetupHookImage.tag }}
+          image: {{ printf "%s/%s/%s:%s" (default .Values.images.preSetupHookImage.registry .Values.images.registry) (default .Values.images.preSetupHookImage.repo .Values.images.repo) .Values.images.preSetupHookImage.imageName .Values.images.preSetupHookImage.tag }}
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           command: [ "/pxcentral-hook/bin/pxcentral-hook" ]
           args: [ "--hook=preflight-check" ]

--- a/charts/px-central/templates/px-backup/pre-rollback-hook/pre-rollback-check.yaml
+++ b/charts/px-central/templates/px-backup/pre-rollback-hook/pre-rollback-check.yaml
@@ -38,7 +38,7 @@ spec:
               {{- end }}
       containers:
         - name: pxbackup-pre-rollback-check
-          image: {{ printf "%s/%s/%s:%s" .Values.images.preSetupHookImage.registry .Values.images.preSetupHookImage.repo .Values.images.preSetupHookImage.imageName .Values.images.preSetupHookImage.tag }}
+          image: {{ printf "%s/%s/%s:%s" (default .Values.images.preSetupHookImage.registry .Values.images.registry) (default .Values.images.preSetupHookImage.repo .Values.images.repo) .Values.images.preSetupHookImage.imageName .Values.images.preSetupHookImage.tag }}
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           command:
             - sh

--- a/charts/px-central/templates/px-backup/pre-upgrade-hook/pre-upgrade-check.yaml
+++ b/charts/px-central/templates/px-backup/pre-upgrade-hook/pre-upgrade-check.yaml
@@ -11,7 +11,7 @@
   {{- if $sts }}
 
     # Expected image from helm chart values
-    {{- $expectedImage := printf "%s/%s/%s:%s" .Values.images.mongodbImage.registry .Values.images.mongodbImage.repo .Values.images.mongodbImage.imageName .Values.images.mongodbImage.tag -}}
+    {{- $expectedImage := printf "%s/%s/%s:%s" (default .Values.images.mongodbImage.registry .Values.images.registry) (default .Values.images.mongodbImage.repo .Values.images.repo) .Values.images.mongodbImage.imageName .Values.images.mongodbImage.tag -}}
 
     {{- range $container := $sts.spec.template.spec.containers }}
       {{- if ne $container.image $expectedImage }}
@@ -179,7 +179,7 @@ spec:
               {{- end }}
       containers:
         - name: pxc-pre-upgrade
-          image: {{ printf "%s/%s/%s:%s" .Values.images.preSetupHookImage.registry .Values.images.preSetupHookImage.repo .Values.images.preSetupHookImage.imageName .Values.images.preSetupHookImage.tag }}
+          image: {{ printf "%s/%s/%s:%s" (default .Values.images.preSetupHookImage.registry .Values.images.registry) (default .Values.images.preSetupHookImage.repo .Values.images.repo) .Values.images.preSetupHookImage.imageName .Values.images.preSetupHookImage.tag }}
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           command: ["/pxcentral-hook/bin/pxcentral-hook"]
           args: ["--hook=pre-upgrade"]
@@ -237,7 +237,7 @@ spec:
             - name: POSTGRES_CONTAINER_NAME
               value: pxcentral-keycloak-postgresql
             - name: POSTGRES_TARGET_IMAGE
-              value: {{ printf "%s/%s/%s:%s" .Values.images.keycloakBackendImage.registry .Values.images.keycloakBackendImage.repo .Values.images.keycloakBackendImage.imageName .Values.images.keycloakBackendImage.tag }}
+              value: {{ printf "%s/%s/%s:%s" (default .Values.images.keycloakBackendImage.registry .Values.images.registry) (default .Values.images.keycloakBackendImage.repo .Values.images.repo) .Values.images.keycloakBackendImage.imageName .Values.images.keycloakBackendImage.tag }}
             - name: POSTGRESQL_PORT_NUMBER
               value: "5432"
             - name: POSTGRESQL_VOLUME_DIR

--- a/charts/px-central/templates/px-backup/pxcentral-alertmanager.yaml
+++ b/charts/px-central/templates/px-backup/pxcentral-alertmanager.yaml
@@ -81,7 +81,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.podIP
-      image: {{ printf "%s/%s/%s:%s" .Values.images.pxBackupAlertmanagerImage.registry .Values.images.pxBackupAlertmanagerImage.repo .Values.images.pxBackupAlertmanagerImage.imageName .Values.images.pxBackupAlertmanagerImage.tag }}
+      image: {{ printf "%s/%s/%s:%s" (default .Values.images.pxBackupAlertmanagerImage.registry .Values.images.registry) (default .Values.images.pxBackupAlertmanagerImage.repo .Values.images.repo) .Values.images.pxBackupAlertmanagerImage.imageName .Values.images.pxBackupAlertmanagerImage.tag }}
       name: alertmanager
       ports:
         - containerPort: 9093

--- a/charts/px-central/templates/px-backup/pxcentral-backup.yaml
+++ b/charts/px-central/templates/px-backup/pxcentral-backup.yaml
@@ -236,7 +236,7 @@ spec:
         - name: SSL_CERT_DIR
           value: /tmp/certs
         {{- end }}
-        image: {{ printf "%s/%s/%s:%s" .Values.images.pxBackupImage.registry .Values.images.pxBackupImage.repo .Values.images.pxBackupImage.imageName .Values.images.pxBackupImage.tag }}
+        image: {{ printf "%s/%s/%s:%s" (default .Values.images.pxBackupImage.registry .Values.images.registry) (default .Values.images.pxBackupImage.repo .Values.images.repo) .Values.images.pxBackupImage.imageName .Values.images.pxBackupImage.tag }}
         imagePullPolicy: {{ .Values.images.pullPolicy }}
         name: px-backup
         ports:

--- a/charts/px-central/templates/px-backup/pxcentral-mongodb.yaml
+++ b/charts/px-central/templates/px-backup/pxcentral-mongodb.yaml
@@ -201,7 +201,7 @@ spec:
       {{- end }}
       containers:
         - name: mongodb
-          image: {{ printf "%s/%s/%s:%s" .Values.images.mongodbImage.registry .Values.images.mongodbImage.repo .Values.images.mongodbImage.imageName .Values.images.mongodbImage.tag }}
+          image: {{ printf "%s/%s/%s:%s" (default .Values.images.mongodbImage.registry .Values.images.registry) (default .Values.images.mongodbImage.repo .Values.images.repo) .Values.images.mongodbImage.imageName .Values.images.mongodbImage.tag }}
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           command:
             - /scripts/setup.sh

--- a/charts/px-central/templates/px-backup/pxcentral-prometheus.yaml
+++ b/charts/px-central/templates/px-backup/pxcentral-prometheus.yaml
@@ -153,8 +153,8 @@ spec:
       - args:
           - -namespaces={{ .Release.Namespace }}
           - --kubelet-service={{ .Release.Namespace }}/kubelet
-          - --prometheus-config-reloader={{ printf "%s/%s/%s:%s" .Values.images.pxBackupPrometheusConfigReloaderImage.registry .Values.images.pxBackupPrometheusConfigReloaderImage.repo .Values.images.pxBackupPrometheusConfigReloaderImage.imageName .Values.images.pxBackupPrometheusConfigReloaderImage.tag }}
-        image: {{ printf "%s/%s/%s:%s" .Values.images.pxBackupPrometheusOperatorImage.registry .Values.images.pxBackupPrometheusOperatorImage.repo .Values.images.pxBackupPrometheusOperatorImage.imageName .Values.images.pxBackupPrometheusOperatorImage.tag }}
+          - --prometheus-config-reloader={{ printf "%s/%s/%s:%s" (default .Values.images.pxBackupPrometheusConfigReloaderImage.registry .Values.images.registry) (default .Values.images.pxBackupPrometheusConfigReloaderImage.repo .Values.images.repo) .Values.images.pxBackupPrometheusConfigReloaderImage.imageName .Values.images.pxBackupPrometheusConfigReloaderImage.tag }}
+        image: {{ printf "%s/%s/%s:%s" (default .Values.images.pxBackupPrometheusOperatorImage.registry .Values.images.registry) (default .Values.images.pxBackupPrometheusOperatorImage.repo .Values.images.repo) .Values.images.pxBackupPrometheusOperatorImage.imageName .Values.images.pxBackupPrometheusOperatorImage.tag }}
         name: prometheus-operator
         ports:
           - containerPort: 8080
@@ -357,7 +357,7 @@ spec:
     {{- if or (empty .Values.proxy.includeNoProxyList) (has "px-backup-dashboard-prometheus" .Values.proxy.includeNoProxyList) }}
     {{ include "proxy.proxyEnv" . | nindent 4 }}
     {{- end }}
-    image: {{ printf "%s/%s/%s:%s" .Values.images.pxBackupPrometheusImage.registry .Values.images.pxBackupPrometheusImage.repo .Values.images.pxBackupPrometheusImage.imageName .Values.images.pxBackupPrometheusImage.tag }}
+    image: {{ printf "%s/%s/%s:%s" (default .Values.images.pxBackupPrometheusImage.registry .Values.images.registry) (default .Values.images.pxBackupPrometheusImage.repo .Values.images.repo) .Values.images.pxBackupPrometheusImage.imageName .Values.images.pxBackupPrometheusImage.tag }}
     livenessProbe:
       exec:
         command:

--- a/charts/px-central/templates/px-license-server/deployment.yaml
+++ b/charts/px-central/templates/px-license-server/deployment.yaml
@@ -49,7 +49,7 @@ spec:
       serviceAccountName: pxcentral-apiserver
       containers:
         - name: pxcentral-license-server
-          image: {{ printf "%s/%s/%s:%s" .Values.images.licenseServerImage.registry .Values.images.licenseServerImage.repo .Values.images.licenseServerImage.imageName .Values.images.licenseServerImage.tag }}
+          image: {{ printf "%s/%s/%s:%s" (default .Values.images.licenseServerImage.registry .Values.images.registry) (default .Values.images.licenseServerImage.repo .Values.images.repo) .Values.images.licenseServerImage.imageName .Values.images.licenseServerImage.tag }}
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           args:
             {{- if eq $UATLSType true }}

--- a/charts/px-central/templates/px-lighthouse/px-central-oidc/pxcentral-keycloak.yaml
+++ b/charts/px-central/templates/px-lighthouse/px-central-oidc/pxcentral-keycloak.yaml
@@ -352,7 +352,7 @@ spec:
       {{- end }}
       containers:
         - name: pxcentral-keycloak-postgresql
-          image: {{ printf "%s/%s/%s:%s" .Values.images.keycloakBackendImage.registry .Values.images.keycloakBackendImage.repo .Values.images.keycloakBackendImage.imageName .Values.images.keycloakBackendImage.tag }}
+          image: {{ printf "%s/%s/%s:%s" (default .Values.images.keycloakBackendImage.registry .Values.images.registry) (default .Values.images.keycloakBackendImage.repo .Values.images.repo) .Values.images.keycloakBackendImage.imageName .Values.images.keycloakBackendImage.tag }}
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           {{ if eq $operatorToChartUpgrade true }}
           securityContext:
@@ -524,7 +524,7 @@ spec:
       {{- end }}
       initContainers:
         - name: wait-for-postgresql
-          image: "{{ .Values.images.keycloakInitContainerImage.registry }}/{{ .Values.images.keycloakInitContainerImage.repo }}/{{ .Values.images.keycloakInitContainerImage.imageName }}:{{ .Values.images.keycloakInitContainerImage.tag }}"
+          image: "{{ default .Values.images.keycloakInitContainerImage.registry .Values.images.registry }}/{{ default .Values.images.keycloakInitContainerImage.repo .Values.images.repo }}/{{ .Values.images.keycloakInitContainerImage.imageName }}:{{ .Values.images.keycloakInitContainerImage.tag }}"
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           command:
             - sh
@@ -550,7 +550,7 @@ spec:
           {{ include "proxy.proxyEnv" . | nindent 10 }}
           {{- end }}
           {{- end }}
-          image: {{ printf "%s/%s/%s:%s" .Values.images.keycloakLoginThemeImage.registry .Values.images.keycloakLoginThemeImage.repo .Values.images.keycloakLoginThemeImage.imageName .Values.images.keycloakLoginThemeImage.tag }}
+          image: {{ printf "%s/%s/%s:%s" (default .Values.images.keycloakLoginThemeImage.registry .Values.images.registry) (default .Values.images.keycloakLoginThemeImage.repo .Values.images.repo) .Values.images.keycloakLoginThemeImage.imageName .Values.images.keycloakLoginThemeImage.tag }}
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           command:
             - sh
@@ -570,7 +570,7 @@ spec:
           {{- end }}
       containers:
         - name: keycloak
-          image: {{ printf "%s/%s/%s:%s" .Values.images.keycloakFrontendImage.registry .Values.images.keycloakFrontendImage.repo .Values.images.keycloakFrontendImage.imageName .Values.images.keycloakFrontendImage.tag }}
+          image: {{ printf "%s/%s/%s:%s" (default .Values.images.keycloakFrontendImage.registry .Values.images.registry) (default .Values.images.keycloakFrontendImage.repo .Values.images.repo) .Values.images.keycloakFrontendImage.imageName .Values.images.keycloakFrontendImage.tag }}
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           command:
             - /scripts/keycloak.sh

--- a/charts/px-central/templates/px-lighthouse/px-central-ui/pxcentral-lighthouse.yaml
+++ b/charts/px-central/templates/px-lighthouse/px-central-ui/pxcentral-lighthouse.yaml
@@ -145,7 +145,7 @@ spec:
               {{- end }}
       containers:
       - name: pxcentral-lh-middleware
-        image: {{ printf "%s/%s/%s:%s" .Values.images.pxcentralMiddlewareImage.registry .Values.images.pxcentralMiddlewareImage.repo .Values.images.pxcentralMiddlewareImage.imageName .Values.images.pxcentralMiddlewareImage.tag }}
+        image: {{ printf "%s/%s/%s:%s" (default .Values.images.pxcentralMiddlewareImage.registry .Values.images.registry) (default .Values.images.pxcentralMiddlewareImage.repo .Values.images.repo) .Values.images.pxcentralMiddlewareImage.imageName .Values.images.pxcentralMiddlewareImage.tag }}
         imagePullPolicy: {{ .Values.images.pullPolicy }}
         env:
           - name: K8S_QPS

--- a/charts/px-central/templates/px-lighthouse/px-central-ui/pxcentral-ui.yaml
+++ b/charts/px-central/templates/px-lighthouse/px-central-ui/pxcentral-ui.yaml
@@ -170,7 +170,7 @@ spec:
               {{- end }}
       initContainers:
         - name: init-mysql-db
-          image: {{ printf "%s/%s/%s:%s" .Values.images.pxcentralBackendImage.registry .Values.images.pxcentralBackendImage.repo .Values.images.pxcentralBackendImage.imageName .Values.images.pxcentralBackendImage.tag }}
+          image: {{ printf "%s/%s/%s:%s" (default .Values.images.pxcentralBackendImage.registry .Values.images.registry) (default .Values.images.pxcentralBackendImage.repo .Values.images.repo) .Values.images.pxcentralBackendImage.imageName .Values.images.pxcentralBackendImage.tag }}
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           command:
             - bash
@@ -219,7 +219,7 @@ spec:
                 name: pxcentral-ui-configmap
       containers:
         - name: pxcentral-backend
-          image: {{ printf "%s/%s/%s:%s" .Values.images.pxcentralBackendImage.registry .Values.images.pxcentralBackendImage.repo .Values.images.pxcentralBackendImage.imageName .Values.images.pxcentralBackendImage.tag }}
+          image: {{ printf "%s/%s/%s:%s" (default .Values.images.pxcentralBackendImage.registry .Values.images.registry) (default .Values.images.pxcentralBackendImage.repo .Values.images.repo) .Values.images.pxcentralBackendImage.imageName .Values.images.pxcentralBackendImage.tag }}
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           ports:
             - containerPort: 80
@@ -358,7 +358,7 @@ spec:
               {{- end }}
       containers:
         - name: pxcentral-frontend
-          image: {{ printf "%s/%s/%s:%s" .Values.images.pxcentralFrontendImage.registry .Values.images.pxcentralFrontendImage.repo .Values.images.pxcentralFrontendImage.imageName .Values.images.pxcentralFrontendImage.tag }}
+          image: {{ printf "%s/%s/%s:%s" (default .Values.images.pxcentralFrontendImage.registry .Values.images.registry) (default .Values.images.pxcentralFrontendImage.repo .Values.images.repo) .Values.images.pxcentralFrontendImage.imageName .Values.images.pxcentralFrontendImage.tag }}
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           ports:
             - name : http
@@ -538,7 +538,7 @@ spec:
       {{- end }}
       initContainers:
       - name: init-mysql
-        image: {{ printf "%s/%s/%s:%s" .Values.images.mysqlInitImage.registry .Values.images.mysqlInitImage.repo .Values.images.mysqlInitImage.imageName .Values.images.mysqlInitImage.tag }}
+        image: {{ printf "%s/%s/%s:%s" (default .Values.images.mysqlInitImage.registry .Values.images.registry) (default .Values.images.mysqlInitImage.repo .Values.images.repo) .Values.images.mysqlInitImage.imageName .Values.images.mysqlInitImage.tag }}
         command: ['sh', '-c', 'rmdir /var/lib/mysql/lost+found || true']
         volumeMounts:
         - mountPath: /var/lib/mysql
@@ -551,7 +551,7 @@ spec:
         {{- end }}
       containers:
         - name: mysql
-          image: {{ printf "%s/%s/%s:%s" .Values.images.mysqlImage.registry .Values.images.mysqlImage.repo .Values.images.mysqlImage.imageName .Values.images.mysqlImage.tag }}
+          image: {{ printf "%s/%s/%s:%s" (default .Values.images.mysqlImage.registry .Values.images.registry) (default .Values.images.mysqlImage.repo .Values.images.repo) .Values.images.mysqlImage.imageName .Values.images.mysqlImage.tag }}
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           args:
           ports:

--- a/charts/px-central/templates/px-lighthouse/pxcentral-api-server.yaml
+++ b/charts/px-central/templates/px-lighthouse/pxcentral-api-server.yaml
@@ -142,7 +142,7 @@ spec:
               {{- end }}
       containers:
       - name: pxcentral-apiserver
-        image: {{ printf "%s/%s/%s:%s" .Values.images.pxcentralApiServerImage.registry .Values.images.pxcentralApiServerImage.repo .Values.images.pxcentralApiServerImage.imageName .Values.images.pxcentralApiServerImage.tag }}
+        image: {{ printf "%s/%s/%s:%s" (default .Values.images.pxcentralApiServerImage.registry .Values.images.registry) (default .Values.images.pxcentralApiServerImage.repo .Values.images.repo) .Values.images.pxcentralApiServerImage.imageName .Values.images.pxcentralApiServerImage.tag }}
         imagePullPolicy: {{ .Values.images.pullPolicy }}
         env:
           - name: PXC_NAMESPACE

--- a/charts/px-central/templates/px-lighthouse/pxcentral-post-install-hook.yaml
+++ b/charts/px-central/templates/px-lighthouse/pxcentral-post-install-hook.yaml
@@ -44,7 +44,7 @@ spec:
       {{- end }}
       containers:
       - name: pxcentral-post-setup
-        image: {{ printf "%s/%s/%s:%s" .Values.images.postInstallSetupImage.registry .Values.images.postInstallSetupImage.repo .Values.images.postInstallSetupImage.imageName .Values.images.postInstallSetupImage.tag }}
+        image: {{ printf "%s/%s/%s:%s" (default .Values.images.postInstallSetupImage.registry .Values.images.registry) (default .Values.images.postInstallSetupImage.repo .Values.images.repo) .Values.images.postInstallSetupImage.imageName .Values.images.postInstallSetupImage.tag }}
         imagePullPolicy: {{ .Values.images.pullPolicy }}
         env:
           - name: LOG_LEVEL

--- a/charts/px-central/templates/px-monitor/cortex/cortex-backend.yaml
+++ b/charts/px-central/templates/px-monitor/cortex/cortex-backend.yaml
@@ -159,7 +159,7 @@ spec:
                 export CASSANDRA_IGNORE_INITDB_SCRIPTS=1
               fi
               /entrypoint.sh /run.sh
-          image: {{ printf "%s/%s/%s:%s" .Values.images.cassandraImage.registry .Values.images.cassandraImage.repo .Values.images.cassandraImage.imageName .Values.images.cassandraImage.tag }}
+          image: {{ printf "%s/%s/%s:%s" (default .Values.images.cassandraImage.registry .Values.images.registry) (default .Values.images.cassandraImage.repo .Values.images.repo) .Values.images.cassandraImage.imageName .Values.images.cassandraImage.tag }}
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           env:
             - name: BITNAMI_DEBUG

--- a/charts/px-central/templates/px-monitor/cortex/cortex-sts.yaml
+++ b/charts/px-central/templates/px-monitor/cortex/cortex-sts.yaml
@@ -126,7 +126,7 @@ spec:
       {{- end }}
       containers:
       - name: pxcentral-memcached-index-read
-        image: {{ printf "%s/%s/%s:%s" .Values.images.memcachedIndexImage.registry .Values.images.memcachedIndexImage.repo .Values.images.memcachedIndexImage.imageName .Values.images.memcachedIndexImage.tag }}
+        image: {{ printf "%s/%s/%s:%s" (default .Values.images.memcachedIndexImage.registry .Values.images.registry) (default .Values.images.memcachedIndexImage.repo .Values.images.repo) .Values.images.memcachedIndexImage.imageName .Values.images.memcachedIndexImage.tag }}
         imagePullPolicy: {{ .Values.images.pullPolicy }}
         command:
         - memcached
@@ -163,7 +163,7 @@ spec:
             readOnly: true
         {{- end }}
       - name: metrics
-        image: {{ printf "%s/%s/%s:%s" .Values.images.memcachedMetricsImage.registry .Values.images.memcachedMetricsImage.repo .Values.images.memcachedMetricsImage.imageName .Values.images.memcachedMetricsImage.tag }}
+        image: {{ printf "%s/%s/%s:%s" (default .Values.images.memcachedMetricsImage.registry .Values.images.registry) (default .Values.images.memcachedMetricsImage.repo .Values.images.repo) .Values.images.memcachedMetricsImage.imageName .Values.images.memcachedMetricsImage.tag }}
         imagePullPolicy: {{ .Values.images.pullPolicy }}
         ports:
         - name: metrics
@@ -250,7 +250,7 @@ spec:
       {{- end }}
       containers:
       - name: pxcentral-memcached-index-write
-        image: {{ printf "%s/%s/%s:%s" .Values.images.memcachedIndexImage.registry .Values.images.memcachedIndexImage.repo .Values.images.memcachedIndexImage.imageName .Values.images.memcachedIndexImage.tag }}
+        image: {{ printf "%s/%s/%s:%s" (default .Values.images.memcachedIndexImage.registry .Values.images.registry) (default .Values.images.memcachedIndexImage.repo .Values.images.repo) .Values.images.memcachedIndexImage.imageName .Values.images.memcachedIndexImage.tag }}
         imagePullPolicy: {{ .Values.images.pullPolicy }}
         command:
         - memcached
@@ -287,7 +287,7 @@ spec:
             readOnly: true
         {{- end }}
       - name: metrics
-        image: {{ printf "%s/%s/%s:%s" .Values.images.memcachedMetricsImage.registry .Values.images.memcachedMetricsImage.repo .Values.images.memcachedMetricsImage.imageName .Values.images.memcachedMetricsImage.tag }}
+        image: {{ printf "%s/%s/%s:%s" (default .Values.images.memcachedMetricsImage.registry .Values.images.registry) (default .Values.images.memcachedMetricsImage.repo .Values.images.repo) .Values.images.memcachedMetricsImage.imageName .Values.images.memcachedMetricsImage.tag }}
         imagePullPolicy: {{ .Values.images.pullPolicy }}
         ports:
         - name: metrics
@@ -374,7 +374,7 @@ spec:
       {{- end }}
       containers:
       - name: pxcentral-memcached
-        image: {{ printf "%s/%s/%s:%s" .Values.images.memcachedImage.registry .Values.images.memcachedImage.repo .Values.images.memcachedImage.imageName .Values.images.memcachedImage.tag }}
+        image: {{ printf "%s/%s/%s:%s" (default .Values.images.memcachedImage.registry .Values.images.registry) (default .Values.images.memcachedImage.repo .Values.images.repo) .Values.images.memcachedImage.imageName .Values.images.memcachedImage.tag }}
         imagePullPolicy: {{ .Values.images.pullPolicy }}
         command:
         - memcached
@@ -410,7 +410,7 @@ spec:
             readOnly: true
         {{- end }}
       - name: metrics
-        image: {{ printf "%s/%s/%s:%s" .Values.images.memcachedMetricsImage.registry .Values.images.memcachedMetricsImage.repo .Values.images.memcachedMetricsImage.imageName .Values.images.memcachedMetricsImage.tag }}
+        image: {{ printf "%s/%s/%s:%s" (default .Values.images.memcachedMetricsImage.registry .Values.images.registry) (default .Values.images.memcachedMetricsImage.repo .Values.images.repo) .Values.images.memcachedMetricsImage.imageName .Values.images.memcachedMetricsImage.tag }}
         imagePullPolicy: {{ .Values.images.pullPolicy }}
         ports:
         - name: metrics
@@ -503,7 +503,7 @@ spec:
       {{- end }}
       containers:
         - name: consul
-          image: {{ printf "%s/%s/%s:%s" .Values.images.consulImage.registry .Values.images.consulImage.repo .Values.images.consulImage.imageName .Values.images.consulImage.tag }}
+          image: {{ printf "%s/%s/%s:%s" (default .Values.images.consulImage.registry .Values.images.registry) (default .Values.images.consulImage.repo .Values.images.repo) .Values.images.consulImage.imageName .Values.images.consulImage.tag }}
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           ports:
             - name: http

--- a/charts/px-central/templates/px-monitor/cortex/cortex.yaml
+++ b/charts/px-central/templates/px-monitor/cortex/cortex.yaml
@@ -425,7 +425,7 @@ spec:
       {{- end }}
       containers:
         - name: cortex
-          image: {{ printf "%s/%s/%s:%s" .Values.images.cortexImage.registry .Values.images.cortexImage.repo .Values.images.cortexImage.imageName .Values.images.cortexImage.tag }}
+          image: {{ printf "%s/%s/%s:%s" (default .Values.images.cortexImage.registry .Values.images.registry) (default .Values.images.cortexImage.repo .Values.images.repo) .Values.images.cortexImage.imageName .Values.images.cortexImage.tag }}
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           {{- if .Values.proxy.httpProxy }}
           env:
@@ -567,7 +567,7 @@ spec:
           {{ include "proxy.proxyEnv" . | nindent 10 }}
           {{- end }}
           {{- end }}
-          image: {{ printf "%s/%s/%s:%s" .Values.images.cortexImage.registry .Values.images.cortexImage.repo .Values.images.cortexImage.imageName .Values.images.cortexImage.tag }}
+          image: {{ printf "%s/%s/%s:%s" (default .Values.images.cortexImage.registry .Values.images.registry) (default .Values.images.cortexImage.repo .Values.images.repo) .Values.images.cortexImage.imageName .Values.images.cortexImage.tag }}
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           args:
             - "-target=distributor"
@@ -699,7 +699,7 @@ spec:
       {{- end }}
       containers:
         - name: nginx
-          image: {{ .Values.images.proxyConfigImage.registry }}/{{ .Values.images.proxyConfigImage.repo }}/{{ .Values.images.proxyConfigImage.imageName }}:{{ .Values.images.proxyConfigImage.tag }}
+          image: {{ default .Values.images.proxyConfigImage.registry .Values.images.registry }}/{{ default .Values.images.proxyConfigImage.repo .Values.images.repo }}/{{ .Values.images.proxyConfigImage.imageName }}:{{ .Values.images.proxyConfigImage.tag }}
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           volumeMounts:
             - name: config
@@ -731,7 +731,7 @@ spec:
           {{- end }}
           {{- end }}
         - name: dnsmasq
-          image: {{ printf "%s/%s/%s:%s" .Values.images.dnsmasqImage.registry .Values.images.dnsmasqImage.repo .Values.images.dnsmasqImage.imageName .Values.images.dnsmasqImage.tag }}
+          image: {{ printf "%s/%s/%s:%s" (default .Values.images.dnsmasqImage.registry .Values.images.registry) (default .Values.images.dnsmasqImage.repo .Values.images.repo) .Values.images.dnsmasqImage.imageName .Values.images.dnsmasqImage.tag }}
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           args:
             - --listen
@@ -849,7 +849,7 @@ spec:
       {{- end }}
       containers:
         - name: cortex
-          image: {{ printf "%s/%s/%s:%s" .Values.images.cortexImage.registry .Values.images.cortexImage.repo .Values.images.cortexImage.imageName .Values.images.cortexImage.tag }}
+          image: {{ printf "%s/%s/%s:%s" (default .Values.images.cortexImage.registry .Values.images.registry) (default .Values.images.cortexImage.repo .Values.images.repo) .Values.images.cortexImage.imageName .Values.images.cortexImage.tag }}
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           args:
             - "-target=querier"
@@ -989,7 +989,7 @@ spec:
       {{- end }}
       containers:
         - name: cortex
-          image: {{ printf "%s/%s/%s:%s" .Values.images.cortexImage.registry .Values.images.cortexImage.repo .Values.images.cortexImage.imageName .Values.images.cortexImage.tag }}
+          image: {{ printf "%s/%s/%s:%s" (default .Values.images.cortexImage.registry .Values.images.registry) (default .Values.images.cortexImage.repo .Values.images.repo) .Values.images.cortexImage.imageName .Values.images.cortexImage.tag }}
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           args:
             - "-target=query-frontend"
@@ -1102,7 +1102,7 @@ spec:
       {{- end }}
       containers:
         - name: cortex
-          image: {{ printf "%s/%s/%s:%s" .Values.images.cortexImage.registry .Values.images.cortexImage.repo .Values.images.cortexImage.imageName .Values.images.cortexImage.tag }}
+          image: {{ printf "%s/%s/%s:%s" (default .Values.images.cortexImage.registry .Values.images.registry) (default .Values.images.cortexImage.repo .Values.images.repo) .Values.images.cortexImage.imageName .Values.images.cortexImage.tag }}
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           args:
             - "-target=ruler"
@@ -1221,7 +1221,7 @@ spec:
       {{- end }}
       containers:
         - name: cortex
-          image: {{ printf "%s/%s/%s:%s" .Values.images.cortexImage.registry .Values.images.cortexImage.repo .Values.images.cortexImage.imageName .Values.images.cortexImage.tag }}
+          image: {{ printf "%s/%s/%s:%s" (default .Values.images.cortexImage.registry .Values.images.registry) (default .Values.images.cortexImage.repo .Values.images.repo) .Values.images.cortexImage.imageName .Values.images.cortexImage.tag }}
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           args:
             - "-target=table-manager"
@@ -1372,7 +1372,7 @@ spec:
         {{- end }}
       containers:
         - name: cortex
-          image: {{ printf "%s/%s/%s:%s" .Values.images.cortexImage.registry .Values.images.cortexImage.repo .Values.images.cortexImage.imageName .Values.images.cortexImage.tag }}
+          image: {{ printf "%s/%s/%s:%s" (default .Values.images.cortexImage.registry .Values.images.registry) (default .Values.images.cortexImage.repo .Values.images.repo) .Values.images.cortexImage.imageName .Values.images.cortexImage.tag }}
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           args:
             - "-target=alertmanager"
@@ -1536,7 +1536,7 @@ spec:
         {{- end }}
       containers:
         - name: cortex
-          image: {{ printf "%s/%s/%s:%s" .Values.images.cortexImage.registry .Values.images.cortexImage.repo .Values.images.cortexImage.imageName .Values.images.cortexImage.tag }}
+          image: {{ printf "%s/%s/%s:%s" (default .Values.images.cortexImage.registry .Values.images.registry) (default .Values.images.cortexImage.repo .Values.images.repo) .Values.images.cortexImage.imageName .Values.images.cortexImage.tag }}
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           args:
             - "-target=ingester"

--- a/charts/px-central/templates/px-monitor/grafana/grafana.yaml
+++ b/charts/px-central/templates/px-monitor/grafana/grafana.yaml
@@ -195,7 +195,7 @@ spec:
       {{- end }}
       containers:
         - name: pxcentral-grafana
-          image: {{ printf "%s/%s/%s:%s" .Values.images.grafanaImage.registry .Values.images.grafanaImage.repo .Values.images.grafanaImage.imageName .Values.images.grafanaImage.tag }}
+          image: {{ printf "%s/%s/%s:%s" (default .Values.images.grafanaImage.registry .Values.images.registry) (default .Values.images.grafanaImage.repo .Values.images.repo) .Values.images.grafanaImage.imageName .Values.images.grafanaImage.tag }}
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           {{- if or .Values.caCertsSecretName .Values.proxy.httpProxy.noProxy }}
           env:

--- a/charts/px-central/templates/px-monitor/prometheus/prometheus.yaml
+++ b/charts/px-central/templates/px-monitor/prometheus/prometheus.yaml
@@ -113,7 +113,7 @@ spec:
     {{- if or (empty .Values.proxy.includeNoProxyList) (has "pxcentral-prometheus" .Values.proxy.includeNoProxyList) }}
     {{- include "proxy.proxyEnv" . | nindent 4 }}
     {{- end }}
-    image: {{ printf "%s/%s/%s:%s" .Values.images.prometheusImage.registry .Values.images.prometheusImage.repo .Values.images.prometheusImage.imageName .Values.images.prometheusImage.tag }}
+    image: {{ printf "%s/%s/%s:%s" (default .Values.images.prometheusImage.registry .Values.images.registry) (default .Values.images.prometheusImage.repo .Values.images.repo) .Values.images.prometheusImage.imageName .Values.images.prometheusImage.tag }}
     livenessProbe:
       exec:
         command:
@@ -355,8 +355,8 @@ spec:
         - args:
             - -namespaces={{ .Release.Namespace }}
             - --kubelet-service={{ .Release.Namespace }}/kubelet
-            - --prometheus-config-reloader={{ printf "%s/%s/%s:%s" .Values.images.prometheusConfigReloadrImage.registry .Values.images.prometheusConfigReloadrImage.repo .Values.images.prometheusConfigReloadrImage.imageName .Values.images.prometheusConfigReloadrImage.tag }}
-          image: {{ printf "%s/%s/%s:%s" .Values.images.prometheusOperatorImage.registry .Values.images.prometheusOperatorImage.repo .Values.images.prometheusOperatorImage.imageName .Values.images.prometheusOperatorImage.tag }}
+            - --prometheus-config-reloader={{ printf "%s/%s/%s:%s" (default .Values.images.prometheusConfigReloadrImage.registry .Values.images.registry) (default .Values.images.prometheusConfigReloadrImage.repo .Values.images.repo) .Values.images.prometheusConfigReloadrImage.imageName .Values.images.prometheusConfigReloadrImage.tag }}
+          image: {{ printf "%s/%s/%s:%s" (default .Values.images.prometheusOperatorImage.registry .Values.images.registry) (default .Values.images.prometheusOperatorImage.repo .Values.images.repo) .Values.images.prometheusOperatorImage.imageName .Values.images.prometheusOperatorImage.tag }}
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           name: pxcentral-prometheus-operator
           {{- if .Values.proxy.httpProxy }}

--- a/charts/px-central/values.yaml
+++ b/charts/px-central/values.yaml
@@ -208,6 +208,8 @@ securityContext:
 tolerations: []
 
 images:
+  registry: ""
+  repo: ""
   pullSecrets: []
   pullPolicy: Always
   insecureRegistry: false


### PR DESCRIPTION


**What this PR does / why we need it**: Added global parameter for setting repo and registry to all the images

Precedence :
if images.registry is set , it will be used . Else it will fall back to the image specific registry
if images.repo is set , it will be used . Else it will fall back to the image specific repo


**Which issue(s) this PR fixes** (optional)
Closes # https://purestorage.atlassian.net/browse/PB-11135

**Special notes for your reviewer**:

<img width="1728" alt="Screenshot 2025-06-03 at 12 27 05 PM" src="https://github.com/user-attachments/assets/16818962-d14e-410d-a962-7644b85824b6" />
<img width="1726" alt="Screenshot 2025-06-03 at 12 27 16 PM" src="https://github.com/user-attachments/assets/d41b2a20-778b-4fb1-8fed-7b3b851e3640" />


