### PR TITLE
Add ability to set priorityClassName, annotations and imagePullPolicy

### DIFF
--- a/charts/portworx/README.md
+++ b/charts/portworx/README.md
@@ -155,6 +155,9 @@ The following tables lists the configurable parameters of the Portworx chart and
 | `updateStrategy.minReadySeconds` | Minimum number of seconds that a pod should be ready before the next batch of pods is updated during a rolling update | 1 |
 | `updateStrategy.disruption.allow` | This field is used to enable or disable smart and parallel upgrade. Smart upgrade is disabled by default, Enable it by setting to false. we can use the `maxUnavailable` field to control the maximum number of Portworx nodes that can be upgraded at a time | None |
 | `updateStrategy.autoUpdateComponents` | Specifies the update strategy for the component images. Valid values: None, Once, Always | None |
+| `annotations` | Map of annotations to set on the StorageCluster object itself. | {} |
+| `priorityClassName` | PriorityClassName to be passed to Podspec of px pods for it to be scheduled accordingly | "" |
+| `imagePullPolicy` | ImagePullPolicy specifies the image pull policy for all the images deployed by the operator. The possible values can be `Always` or `IfNotPresent`. | "Always" |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/charts/portworx/templates/storage-cluster.yaml
+++ b/charts/portworx/templates/storage-cluster.yaml
@@ -82,6 +82,9 @@ metadata:
     {{- if eq .Values.skipHealthChecks true }}
     portworx.io/health-check: "skip"
     {{- end }}
+    {{- with .Values.annotations }}
+{{ toYaml . | indent 4 }}
+    {{- end }}
   labels:
     heritage: {{.Release.Service | quote }}
     release: {{.Release.Name | quote }}
@@ -90,7 +93,7 @@ metadata:
     app.kubernetes.io/instance: {{.Release.Name | quote }}
 spec:
   image: portworx/oci-monitor:{{ required "A valid Image tag is required in the SemVer format" .Values.imageVersion }}
-  imagePullPolicy: Always
+  imagePullPolicy: {{ .Values.imagePullPolicy | default "Always" }}
   {{- if not (eq $customRegistryURL "none") }}
   customImageRegistry: {{ $customRegistryURL }}
   {{- end }}
@@ -609,3 +612,7 @@ spec:
     type: {{ .Values.deleteStrategy.type }}
   {{- end }}
 {{- end }}
+  {{- if .Values.priorityClassName }}
+  priorityClassName: {{ .Values.priorityClassName }}
+  {{- end }}
+

--- a/charts/portworx/values.yaml
+++ b/charts/portworx/values.yaml
@@ -298,3 +298,7 @@ updateStrategy:
 
   autoUpdateComponents:                   # Indicates the update strategy for the component images
                                           # valid values None,Once,Always
+
+annotations:                              # Map of annotations to set on the StorageCluster object itself.
+priorityClassName:                        # PriorityClassName to be passed to Podspec of px pods for it to be scheduled accordingly
+imagePullPolicy:                          # ImagePullPolicy specifies the image pull policy for all the images deployed by the operator. The possible values can be `Always` or `IfNotPresent`. Default value is `Always`.

--- a/test/portworx/storagecluster_helm_template_test.go
+++ b/test/portworx/storagecluster_helm_template_test.go
@@ -303,6 +303,31 @@ func TestStorageClusterHelmTemplate(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:           "TestAnnotations",
+			resultFileName: "storagecluster_annotations.yaml",
+			helmOption: &helm.Options{
+				ValuesFiles: []string{"./testValues/storagecluster_annotations.yaml"},
+			},
+		},
+		{
+			name:           "TestPriorityClassName",
+			resultFileName: "storagecluster_priorityclassname.yaml",
+			helmOption: &helm.Options{
+				SetValues: map[string]string{
+					"priorityClassName": "system-cluster-critical",
+				},
+			},
+		},
+		{
+			name:           "TestImagePullPolicy",
+			resultFileName: "storagecluster_imagepullpolicy.yaml",
+			helmOption: &helm.Options{
+				SetValues: map[string]string{
+					"imagePullPolicy": "IfNotPresent",
+				},
+			},
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/test/portworx/testValues/storagecluster_annotations.yaml
+++ b/test/portworx/testValues/storagecluster_annotations.yaml
@@ -1,0 +1,2 @@
+annotations:                       
+  foo: bar

--- a/test/portworx/testspec/storagecluster_annotations.yaml
+++ b/test/portworx/testspec/storagecluster_annotations.yaml
@@ -1,0 +1,31 @@
+kind: StorageCluster
+apiVersion: core.libopenstorage.org/v1
+metadata:
+  name: "mycluster"
+  namespace: portworx
+  annotations:
+    foo: bar
+  labels:
+    heritage: "Helm"
+    release: "my-release"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "my-release"
+spec:
+  image: portworx/oci-monitor:3.3.0.1
+  imagePullPolicy: Always
+
+  kvdb:
+    internal: true
+  storage:
+    useAll: true
+  secretsProvider: k8s
+  
+  stork:
+    enabled: true
+  monitoring:
+    telemetry:
+      enabled: true
+  csi:
+    enabled: true
+  autopilot:
+    enabled: true

--- a/test/portworx/testspec/storagecluster_imagepullpolicy.yaml
+++ b/test/portworx/testspec/storagecluster_imagepullpolicy.yaml
@@ -1,0 +1,31 @@
+kind: StorageCluster
+apiVersion: core.libopenstorage.org/v1
+metadata:
+  name: "mycluster"
+  namespace: portworx
+  annotations:
+  labels:
+    heritage: "Helm"
+    release: "my-release"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "my-release"
+spec:
+  image: portworx/oci-monitor:3.3.0.1
+  imagePullPolicy: IfNotPresent
+
+  kvdb:
+    internal: true
+  storage:
+    useAll: true
+  secretsProvider: k8s
+  
+  stork:
+    enabled: true
+  monitoring:
+    telemetry:
+      enabled: true
+  csi:
+    enabled: true
+  autopilot:
+    enabled: true
+  

--- a/test/portworx/testspec/storagecluster_priorityclassname.yaml
+++ b/test/portworx/testspec/storagecluster_priorityclassname.yaml
@@ -1,0 +1,31 @@
+kind: StorageCluster
+apiVersion: core.libopenstorage.org/v1
+metadata:
+  name: "mycluster"
+  namespace: portworx
+  annotations:
+  labels:
+    heritage: "Helm"
+    release: "my-release"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "my-release"
+spec:
+  image: portworx/oci-monitor:3.3.0.1
+  imagePullPolicy: Always
+
+  kvdb:
+    internal: true
+  storage:
+    useAll: true
+  secretsProvider: k8s
+  
+  stork:
+    enabled: true
+  monitoring:
+    telemetry:
+      enabled: true
+  csi:
+    enabled: true
+  autopilot:
+    enabled: true
+  priorityClassName: system-cluster-critical


### PR DESCRIPTION
- [x] Signed off your work as per the DCO.
- [x] Add unit-tests

**What this PR does / why we need it**:
This PR adds three parameters to the Portworx helm chart:
- annotations: to set annotations on the StorageCluster object
- imagePullPolicy: to set the imagePullPolicy for PX pods 
- priorityClassName: to set PriorityClassName to be passed to Podspec of px pods for it to be scheduled accordingly
