### PR TITLE
PB-12057: Add platform(Rancher) RBAC support for namespace filtering in PXB

### DIFF
--- a/charts/px-central/templates/px-lighthouse/px-central-ui/pxcentral-lighthouse.yaml
+++ b/charts/px-central/templates/px-lighthouse/px-central-ui/pxcentral-lighthouse.yaml
@@ -5,6 +5,7 @@
 {{- $alertmanagerEndpoint := "" }}
 {{- $prometheusSecretName := "" }}
 {{- $alertmanagerSecretName := "" }}
+{{- $usePlatformRbac := .Values.pxbackup.usePlatformRbac | default false }}
 {{- $pxBackupEnabled := .Values.pxbackup.enabled | default false }}
 {{- if eq $pxBackupEnabled true }}
 {{- $deployDedicatedMonitoringSystem := .Values.pxbackup.deployDedicatedMonitoringSystem }}
@@ -152,6 +153,10 @@ spec:
             value: "100"
           - name: K8S_BURST
             value: "100"
+          {{- if eq $usePlatformRbac true }}
+          - name: USE_PLATFORM_RBAC
+            value: "true"
+          {{- end }}
           - name: PX_NAMESPACE
             valueFrom:
               fieldRef:

--- a/charts/px-central/templates/px-lighthouse/px-central-ui/pxcentral-ui-configmap.yaml
+++ b/charts/px-central/templates/px-lighthouse/px-central-ui/pxcentral-ui-configmap.yaml
@@ -19,3 +19,4 @@ data:
   OIDC_AUTHSERVERURL: http://pxcentral-keycloak-http:80/auth/realms/master
   OIDC_SCOPES: openid
   HIDE_KUBE_CONFIG: "False"
+  USE_PLATFORM_RBAC: "{{ .Values.pxbackup.usePlatformRbac }}"

--- a/charts/px-central/values.yaml
+++ b/charts/px-central/values.yaml
@@ -132,6 +132,7 @@ pxbackup:
   volDeleteWorker: 5
   version: 2.10.0
   skipValidations: false
+  usePlatformRbac: false
 
 pxlicenseserver:
   enabled: false


### PR DESCRIPTION
## Summary
This PR adds support for platform RBAC-based namespace filtering in PX-Central UI.

## Changes Made
- Added new configuration option `usePlatformRbac` to `pxbackup` section in values.yaml (defaults to `false`)
- Updated PX-Central Lighthouse deployment template to conditionally set `USE_PLATFORM_RBAC` environment variable
- When enabled, this allows the Lighthouse UI to leverage platform RBAC for namespace-level access control

## Configuration
The feature can be enabled by setting:
```yaml
pxbackup:
  usePlatformRbac: true
  
  
Dummy Helm command to set the usePlatformRbac flag to true:
`helm upgrade --install px-central ./charts/px-central \
  --set pxbackup.enabled=true \
  --set pxbackup.usePlatformRbac=true `
