### PR TITLE
PB-15007 | Add NGINX security headers, access/error logging, and healthz endpoint for frontend pod

### DIFF
--- a/charts/px-central/templates/px-lighthouse/px-central-ui/pxcentral-ui.yaml
+++ b/charts/px-central/templates/px-lighthouse/px-central-ui/pxcentral-ui.yaml
@@ -54,11 +54,22 @@ data:
       listen  8080;
       server_name localhost;
       server_tokens off;
+      access_log /var/log/nginx/access.log;
+      error_log  /var/log/nginx/error.log;
+      location = /healthz {
+        access_log off;
+        return 200 'OK';
+        add_header Content-Type text/plain;
+      }
       location / {
         root   /usr/share/nginx/html;
         add_header Cache-Control "no-cache";
         add_header Referrer-Policy 'no-referrer';
+        add_header X-Frame-Options 'SAMEORIGIN';
+        add_header X-Content-Type-Options 'nosniff';
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' ws: wss:; frame-ancestors 'self';";
         index  index.html index.htm;
+        try_files $uri $uri/ /index.html;
       }
 
       location /backend/ {
@@ -343,14 +354,14 @@ spec:
               containerPort: 443
           readinessProbe:
             httpGet:
-              path: /
+              path: /healthz
               port: 8080
             initialDelaySeconds: 15
             timeoutSeconds: 1
             periodSeconds: 60
           livenessProbe:
             httpGet:
-              path: /
+              path: /healthz
               port: 8080
             initialDelaySeconds: 15
             timeoutSeconds: 1


### PR DESCRIPTION
### Summary
Hardens the NGINX configuration for the pxcentral-frontend pod by adding security headers, enabling access/error logging, and introducing a dedicated health check endpoint to reduce log noise.

### Changes
NGINX Security Headers

- X-Frame-Options: SAMEORIGIN — prevents clickjacking by restricting framing to same origin
- X-Content-Type-Options: nosniff — prevents MIME-type sniffing
- Content-Security-Policy — restricts resource loading to self with necessary exceptions for Angular (unsafe-inline, unsafe-eval); restricts frame ancestors to self

SPA Route Fix
- Added try_files $uri $uri/ /index.html; to the location / block so Angular client-side routes (e.g. /landing/oauth/oidc) fall back to index.html instead of returning a 404 from NGINX

Logging
- Enabled access_log and error_log on the server block for better observability
- Added a dedicated location = /healthz endpoint that returns 200 OK with access_log off to suppress probe noise

Probe Update
- Updated liveness and readiness probe paths from / to /healthz to use the new lightweight health check endpoint and avoid unnecessary log entries from Kubernetes probes

