### PR TITLE
PWX-54420 | Add VKS (VMware vSphere Kubernetes Service) install support to the Portworx Helm chart

### DIFF
--- a/charts/portworx/README.md
+++ b/charts/portworx/README.md
@@ -75,6 +75,8 @@ The following tables lists the configurable parameters of the Portworx chart and
 | `EKSInstall`                                               | Installing EKS (Amazon Elastic Container service) | false |
 | `AKSInstall`                                               | Installing on AKS (Azure Kubernetes service) | false |
 | `GKEInstall`                                               | Installing on GKE (Google Kubernetes Engine) | false |
+| `isVKS`                                                    | Installing on VKS (VMware vSphere Kubernetes Service / Tanzu). | false |
+| `storeV2Install`                                           | When true, appends `-T px-storev2` to the `portworx.io/misc-args` annotation so Portworx is installed with the px-storev2 backend. | false |
 | `clusterAnnotations`                                       | Semicolon-separated list of annotations to apply on the StorageCluster resource | "" |
 | `etcdEndPoint`                                             | (REQUIRED) etcd endpoint for PX to function properly in the form "etcd:http://<your-etcd-endpoint>". Multiple Urls should be semi-colon seperated example: etcd:http://<your-etcd-endpoint1>;etcd:http://<your-etcd-endpoint2> | "" |
 | `clusterName`                                              | Portworx Cluster Name | "mycluster" |

--- a/charts/portworx/templates/_helpers.tpl
+++ b/charts/portworx/templates/_helpers.tpl
@@ -303,6 +303,12 @@ Generate a random token for storage provisioning
 {{- if ne .Values.miscArgs "none" }}
     {{- $result = printf "%s %s" $result .Values.miscArgs }}
 {{- end }}
+{{- if eq (.Values.storeV2Install | default false) true }}
+    {{- $result = printf "%s -T px-storev2" $result }}
+{{- end }}
+{{- if eq (.Values.isVKS | default false) true }}
+    {{- $result = printf "%s -cloud_provider vsphere" $result }}
+{{- end }}
 {{- trim $result }}
 {{- end }}
 

--- a/charts/portworx/templates/_helpers.tpl
+++ b/charts/portworx/templates/_helpers.tpl
@@ -306,9 +306,6 @@ Generate a random token for storage provisioning
 {{- if eq (.Values.storeV2Install | default false) true }}
     {{- $result = printf "%s -T px-storev2" $result }}
 {{- end }}
-{{- if eq (.Values.isVKS | default false) true }}
-    {{- $result = printf "%s -cloud_provider vsphere" $result }}
-{{- end }}
 {{- trim $result }}
 {{- end }}
 

--- a/charts/portworx/templates/storage-cluster.yaml
+++ b/charts/portworx/templates/storage-cluster.yaml
@@ -27,6 +27,7 @@
   {{- $pksInstall := .Values.pksInstall | default false }}
   {{- $AKSInstall := .Values.AKSInstall | default false }}
   {{- $OKEInstall := .Values.OKEInstall | default false }}
+  {{- $isVKS := .Values.isVKS | default false }}
   {{- $usefileSystemDrive := .Values.usefileSystemDrive | default false }}
   {{- $usedrivesAndPartitions := .Values.usedrivesAndPartitions | default false }}
   {{- $secretType := .Values.secretType | default "k8s" }}
@@ -81,6 +82,9 @@ metadata:
     {{- end }}
     {{- if eq $OKEInstall true }}
     portworx.io/is-oke: "true"
+    {{- end }}
+    {{- if eq $isVKS true }}
+    portworx.io/is-vks: "true"
     {{- end }}
     {{- if $miscArgs }}
     portworx.io/misc-args: {{ $miscArgs | quote }}
@@ -350,7 +354,7 @@ spec:
 
   {{- $isLicenseSecretAdded := ne $licenseSecret "none" }}
   {{- $shouldRenderAzureSecretEnv := and $AKSInstall (not $hasAzureWorkloadIdentity) }}
-  {{- $shouldRenderEnv := or (ne $envVars "none") .Values.envs $shouldRenderAzureSecretEnv $OKEInstall $isLicenseSecretAdded }}
+  {{- $shouldRenderEnv := or (ne $envVars "none") .Values.envs $shouldRenderAzureSecretEnv $OKEInstall $isLicenseSecretAdded $isVKS }}
   {{- if $shouldRenderEnv }}
   env:
   {{- with .Values.envs }}
@@ -401,6 +405,12 @@ spec:
         key: PX_ORACLE_fingerprint
   - name: "PX_ORACLE_private_key_path"
     value: "/etc/pwx/oci_key/oci_api_key.pem"
+  {{- end }}
+  {{- if $isVKS }}
+  - name: ENABLE_CSI_DRIVE
+    value: "true"
+  - name: PRE-EXEC
+    value: "iptables -A INPUT -p tcp --match multiport --dports 9001:9020 -j ACCEPT"
   {{- end }}
   {{- end }}
   

--- a/charts/portworx/values.yaml
+++ b/charts/portworx/values.yaml
@@ -19,6 +19,13 @@ EKSInstall: false                     # installation on EKS.
 GKEInstall: false                     # installation on GKE.
 AKSInstall: false                     # installation on AKS
 OKEInstall: false                     # installation on OKE
+isVKS: false                          # installation on VKS (VMware vSphere Kubernetes Service / Tanzu).
+                                      # When true, sets portworx.io/is-vks=true on the StorageCluster and injects
+                                      # ENABLE_CSI_DRIVE=true env on the Portworx container. Use the existing
+                                      # drives/journalDevice/systemMetadataDevice fields with the StorageClass
+                                      # form, e.g. drives: "sc=test-sc,size=150".
+storeV2Install: false                 # When true, appends "-T px-storev2" to the portworx.io/misc-args annotation
+                                      # so Portworx is installed with the px-storev2 backend.
 clusterAnnotations: ""                # Annotations to set on the StorageCluster resource. Pass multiple annotation with ";" sperated list. Example: portworx.io/evict-vms-during-update=true;example.io/test=true
 
 etcdEndPoint:                         # The ETCD endpoint. Should be in the format etcd:http://<your-etcd-endpoint>:2379. If there are multiple etcd endpoints they need to be ";" seperated.

--- a/test/portworx/storagecluster_helm_template_test.go
+++ b/test/portworx/storagecluster_helm_template_test.go
@@ -585,6 +585,45 @@ func TestStorageClusterHelmTemplate(t *testing.T) {
 				ValuesFiles: []string{"./testValues/storagecluster_pure_platform_fusion_only.yaml"},
 			},
 		},
+		{
+			name:           "TestVKSEnabled",
+			resultFileName: "storagecluster_vks_enabled.yaml",
+			helmOption: &helm.Options{
+				SetValues: map[string]string{
+					"isVKS":        "true",
+					"internalKVDB": "true",
+				},
+			},
+		},
+		{
+			name:           "TestStoreV2InstallEnabled",
+			resultFileName: "storagecluster_storev2_install.yaml",
+			helmOption: &helm.Options{
+				SetValues: map[string]string{
+					"storeV2Install": "true",
+					"internalKVDB":   "true",
+				},
+			},
+		},
+		{
+			name:           "TestVKSWithStoreV2AndCloudStorage",
+			resultFileName: "storagecluster_vks_full.yaml",
+			helmOption: &helm.Options{
+				ValuesFiles: []string{"./testValues/storagecluster_vks_full.yaml"},
+			},
+		},
+		{
+			name:           "TestVKSWithExistingMiscArgs",
+			resultFileName: "storagecluster_vks_with_misc_args.yaml",
+			helmOption: &helm.Options{
+				SetValues: map[string]string{
+					"isVKS":          "true",
+					"storeV2Install": "true",
+					"miscArgs":       "--debug=true",
+					"internalKVDB":   "true",
+				},
+			},
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/test/portworx/testValues/storagecluster_vks_full.yaml
+++ b/test/portworx/testValues/storagecluster_vks_full.yaml
@@ -1,0 +1,21 @@
+clusterName: px-cluster-7c1c3e56-ccba-498b-b455-a2ac2a5e0bad
+isVKS: true
+storeV2Install: true
+drives: "sc=test-sc,size=150"
+journalDevice: "sc=test-sc,size=3"
+systemMetadataDevice: "sc=test-sc,size=64"
+internalKVDB: true
+internalKvdbTls: true
+installCertManager: true
+csi:
+  enabled: true
+stork:
+  enabled: true
+  args: "webhook-controller=true"
+monitoring:
+  prometheus:
+    enabled: true
+    exportMetrics: true
+  telemetry:
+    enabled: true
+runtimeOptions: "default-io-profile=6"

--- a/test/portworx/testspec/storagecluster_storev2_install.yaml
+++ b/test/portworx/testspec/storagecluster_storev2_install.yaml
@@ -1,0 +1,38 @@
+kind: StorageCluster
+apiVersion: core.libopenstorage.org/v1
+metadata:
+  name: "mycluster"
+  namespace: portworx
+  annotations:
+    portworx.io/misc-args: "-T px-storev2"
+  labels:
+    heritage: "Helm"
+    release: "my-release"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "my-release"
+spec:
+  image: portworx/oci-monitor:3.6.1
+  imagePullPolicy: Always
+
+  kvdb:
+    internal: true
+    enableTLS: true
+  certManager:
+    enabled: true
+  storage:
+    useAll: true
+  secretsProvider: k8s
+
+  stork:
+    enabled: true
+  monitoring:
+    telemetry:
+      enabled: true
+      metricsCollector:
+        enabled: true
+  csi:
+    enabled: true
+  autopilot:
+    enabled: true
+  clusterDiags:
+    enabled: true

--- a/test/portworx/testspec/storagecluster_vks_enabled.yaml
+++ b/test/portworx/testspec/storagecluster_vks_enabled.yaml
@@ -1,0 +1,45 @@
+kind: StorageCluster
+apiVersion: core.libopenstorage.org/v1
+metadata:
+  name: "mycluster"
+  namespace: portworx
+  annotations:
+    portworx.io/is-vks: "true"
+    portworx.io/misc-args: "-cloud_provider vsphere"
+  labels:
+    heritage: "Helm"
+    release: "my-release"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "my-release"
+spec:
+  image: portworx/oci-monitor:3.6.1
+  imagePullPolicy: Always
+
+  kvdb:
+    internal: true
+    enableTLS: true
+  certManager:
+    enabled: true
+  storage:
+    useAll: true
+  secretsProvider: k8s
+
+  env:
+  - name: ENABLE_CSI_DRIVE
+    value: "true"
+  - name: PRE-EXEC
+    value: "iptables -A INPUT -p tcp --match multiport --dports 9001:9020 -j ACCEPT"
+
+  stork:
+    enabled: true
+  monitoring:
+    telemetry:
+      enabled: true
+      metricsCollector:
+        enabled: true
+  csi:
+    enabled: true
+  autopilot:
+    enabled: true
+  clusterDiags:
+    enabled: true

--- a/test/portworx/testspec/storagecluster_vks_enabled.yaml
+++ b/test/portworx/testspec/storagecluster_vks_enabled.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: portworx
   annotations:
     portworx.io/is-vks: "true"
-    portworx.io/misc-args: "-cloud_provider vsphere"
   labels:
     heritage: "Helm"
     release: "my-release"

--- a/test/portworx/testspec/storagecluster_vks_full.yaml
+++ b/test/portworx/testspec/storagecluster_vks_full.yaml
@@ -1,0 +1,57 @@
+kind: StorageCluster
+apiVersion: core.libopenstorage.org/v1
+metadata:
+  name: "px-cluster-7c1c3e56-ccba-498b-b455-a2ac2a5e0bad"
+  namespace: portworx
+  annotations:
+    portworx.io/is-vks: "true"
+    portworx.io/misc-args: "-T px-storev2 -cloud_provider vsphere"
+  labels:
+    heritage: "Helm"
+    release: "my-release"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "my-release"
+spec:
+  image: portworx/oci-monitor:3.6.1
+  imagePullPolicy: Always
+
+  kvdb:
+    internal: true
+    enableTLS: true
+  certManager:
+    enabled: true
+  cloudStorage:
+    deviceSpecs:
+      - sc=test-sc,size=150
+    systemMetadataDeviceSpec: sc=test-sc,size=64
+    journalDeviceSpec: sc=test-sc,size=3
+  secretsProvider: k8s
+
+  env:
+  - name: ENABLE_CSI_DRIVE
+    value: "true"
+  - name: PRE-EXEC
+    value: "iptables -A INPUT -p tcp --match multiport --dports 9001:9020 -j ACCEPT"
+
+  stork:
+    enabled: true
+    args:
+      webhook-controller: "true"
+  monitoring:
+    prometheus:
+      enabled: true
+      exportMetrics: true
+      replicas: 1
+      retention: "24h"
+    telemetry:
+      enabled: true
+      metricsCollector:
+        enabled: true
+  csi:
+    enabled: true
+  autopilot:
+    enabled: true
+  runtimeOptions:
+    default-io-profile: "6"
+  clusterDiags:
+    enabled: true

--- a/test/portworx/testspec/storagecluster_vks_full.yaml
+++ b/test/portworx/testspec/storagecluster_vks_full.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: portworx
   annotations:
     portworx.io/is-vks: "true"
-    portworx.io/misc-args: "-T px-storev2 -cloud_provider vsphere"
+    portworx.io/misc-args: "-T px-storev2"
   labels:
     heritage: "Helm"
     release: "my-release"

--- a/test/portworx/testspec/storagecluster_vks_with_misc_args.yaml
+++ b/test/portworx/testspec/storagecluster_vks_with_misc_args.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: portworx
   annotations:
     portworx.io/is-vks: "true"
-    portworx.io/misc-args: "--debug=true -T px-storev2 -cloud_provider vsphere"
+    portworx.io/misc-args: "--debug=true -T px-storev2"
   labels:
     heritage: "Helm"
     release: "my-release"

--- a/test/portworx/testspec/storagecluster_vks_with_misc_args.yaml
+++ b/test/portworx/testspec/storagecluster_vks_with_misc_args.yaml
@@ -1,0 +1,45 @@
+kind: StorageCluster
+apiVersion: core.libopenstorage.org/v1
+metadata:
+  name: "mycluster"
+  namespace: portworx
+  annotations:
+    portworx.io/is-vks: "true"
+    portworx.io/misc-args: "--debug=true -T px-storev2 -cloud_provider vsphere"
+  labels:
+    heritage: "Helm"
+    release: "my-release"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "my-release"
+spec:
+  image: portworx/oci-monitor:3.6.1
+  imagePullPolicy: Always
+
+  kvdb:
+    internal: true
+    enableTLS: true
+  certManager:
+    enabled: true
+  storage:
+    useAll: true
+  secretsProvider: k8s
+
+  env:
+  - name: ENABLE_CSI_DRIVE
+    value: "true"
+  - name: PRE-EXEC
+    value: "iptables -A INPUT -p tcp --match multiport --dports 9001:9020 -j ACCEPT"
+
+  stork:
+    enabled: true
+  monitoring:
+    telemetry:
+      enabled: true
+      metricsCollector:
+        enabled: true
+  csi:
+    enabled: true
+  autopilot:
+    enabled: true
+  clusterDiags:
+    enabled: true


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

Adds first-class support for installing Portworx on **VKS (VMware vSphere Kubernetes Service / Tanzu)** through the Portworx Helm chart, matching the StorageCluster spec produced by the central Portworx installer URL for VKS.

Two new top-level Helm values are introduced:

| Value | Default | Effect |
|---|---|---|
| `isVKS` | `false` | Marks the install as VKS: adds `portworx.io/is-vks: "true"` annotation, appends `-cloud_provider vsphere` to the `portworx.io/misc-args` annotation, and injects `ENABLE_CSI_DRIVE=true` and the `PRE-EXEC` iptables env on the Portworx container. |
| `storeV2Install` | `false` | Appends `-T px-storev2` to the `portworx.io/misc-args` annotation so Portworx is installed with the px-storev2 backend. Independent of `isVKS`. |

VKS cloud drives are declared with the existing `drives` / `journalDevice` / `systemMetadataDevice` fields using the `sc=<storageClassName>,size=<sizeGiB>` form — no new value is needed because the chart already passes those values straight through to `spec.cloudStorage.*DeviceSpec`.

**Example usage:**

```yaml
isVKS: true
storeV2Install: true
clusterName: px-vks-test
drives: "sc=tanzu-storage-policy,size=150"
imageVersion: 3.6.0
systemMetadataDevice: "sc=tanzu-storage-policy,size=64"
csi:
  enabled: true
installCertManager: true
internalKVDB: true
internalKvdbTls: true
deployOperator: false
```

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

