### PR TITLE
PB-16568: harden px-central MongoDB replica set for HA under load

### DIFF
--- a/charts/px-central/templates/px-backup/pxcentral-mongodb.yaml
+++ b/charts/px-central/templates/px-backup/pxcentral-mongodb.yaml
@@ -114,6 +114,11 @@ spec:
         {{- end }}
       {{- end }}
       serviceAccountName: pxc-backup-mongodb
+      # PB-16568: give a SIGTERM'd mongod time to checkpoint and step down cleanly.
+      # With the default 30s, a starved primary is SIGKILLed on grace expiry and
+      # returns via WiredTiger crash recovery + oplog rollback (un-checkpointed
+      # writes discarded).
+      terminationGracePeriodSeconds: {{ .Values.mongodbTerminationGracePeriodSeconds | default 120 }}
       {{- if $isOpenshiftCluster}}
       {{- else }}
       securityContext:
@@ -185,13 +190,17 @@ spec:
             - containerPort: 27017
               name: mongodb
               protocol: TCP
+          # PB-16568: liveness must only prove the process is alive. A mongosh exec
+          # (Node.js cold-start + connect + auth) cannot finish within a 5s timeout
+          # under node starvation, and asserting replica-set role also fails during
+          # elections -- so the old exec probe would kill a healthy PRIMARY, collapsing
+          # the replica set to ReplicaSetNoPrimary. A cheap TCP check cannot false-fail
+          # under CPU pressure (measured 6ms vs 14-19s for the exec). Role/writability
+          # lives in the readiness probe below, which only removes the pod from the
+          # Service and never restarts the container.
           livenessProbe:
-            exec:
-              command:
-              - bash
-              - -ec
-              - |
-                mongosh --eval 'db.adminCommand("ping") && db.hello().isWritablePrimary || db.hello().secondary' | grep -q 'true'            
+            tcpSocket:
+              port: 27017
             failureThreshold: 6
             initialDelaySeconds: 600
             periodSeconds: 10
@@ -208,7 +217,13 @@ spec:
             initialDelaySeconds: 60
             periodSeconds: 10
             successThreshold: 1
-            timeoutSeconds: 5
+            # PB-16568: widened from 5s -- a starved secondary should be given room
+            # before it is pulled from the Service, to avoid needless endpoint churn.
+            timeoutSeconds: 15
+          {{- if .Values.mongodbResources }}
+          resources:
+{{ toYaml .Values.mongodbResources | indent 12 }}
+          {{- end }}
           volumeMounts:
             - mountPath: /data/db
               name: pxc-mongodb-data
@@ -258,4 +273,26 @@ spec:
         storageClassName: {{ .Values.persistentStorage.storageClassName }}
         {{- end }}
   {{- end }}
+{{- if .Values.mongodbPodDisruptionBudget }}
+---
+# PB-16568: protect replica-set quorum. Without a PDB, a node drain / voluntary
+# disruption can take down 2 of 3 members at once, leaving no primary. minAvailable=2
+# keeps a voting majority (and therefore a primary) available at all times.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: pxc-backup-mongodb
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: pxc-backup-mongodb
+{{- include "px-central.labels" . | nindent 4 }}
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Release.Name }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/managed-by: {{ .Release.Service }}
+      app.kubernetes.io/component: pxc-backup-mongodb
+{{- end }}
 {{- end -}}

--- a/charts/px-central/values.yaml
+++ b/charts/px-central/values.yaml
@@ -25,7 +25,28 @@ persistentStorage:
 
 storkRequired: false
 nodeAffinityLabel: ""
-podAntiAffinity: false
+# PB-16568: default the MongoDB replica-set members onto separate nodes (hard
+# anti-affinity) so a single node failure/drain cannot take down more than one
+# member. Requires >=3 schedulable nodes; set to false for single-/two-node dev.
+podAntiAffinity: true
+
+# PB-16568: MongoDB container resources. Empty ({}) ships BestEffort QoS, which
+# lets the scheduler co-locate load onto the mongo nodes and starves the members
+# first under contention -- the trigger for the ReplicaSetNoPrimary flake. The
+# memory limit MUST exceed persistentStorage.mongoCacheSize (WiredTiger cache, GB)
+# plus overhead, or you trade eviction for OOMKill.
+mongodbResources:
+  requests:
+    cpu: "1"
+    memory: 2Gi
+  limits:
+    cpu: "2"
+    memory: 6Gi
+# PB-16568: seconds a SIGTERM'd mongod gets to checkpoint + step down before SIGKILL.
+mongodbTerminationGracePeriodSeconds: 120
+# PB-16568: create a PodDisruptionBudget (minAvailable=2 of 3) for the MongoDB
+# replica set. Disable for single-/two-node dev where it would block node drains.
+mongodbPodDisruptionBudget: true
 
 caCertsSecretName: ""
 


### PR DESCRIPTION
## Problem

Under cluster load the px-central MongoDB replica set intermittently collapses to `ReplicaSetNoPrimary`, so px-backup API calls fail with `server selection timeout` and in-flight backup/restore operations fail (surfacing as flakes in `BasicBackupAndRestoreWithParallelBackupSchedule`). See **[PB-16568](https://purestorage.atlassian.net/browse/PB-16568)**.

**Root cause:** the MongoDB liveness probe execs `mongosh` (Node.js cold-start + connect + auth) with a 5s timeout and asserts replica-set role. Because the pods are **BestEffort** (`resources: {}`), under node CPU/IO/network contention the `mongosh` exec cannot finish within 5s; after 6 failures kubelet kills the container — and when the killed member is the **primary**, this forces an election and the `ReplicaSetNoPrimary` window that fails px-backup.

## Reproduced and fix-validated on a live cluster

| Metric | Old (`mongosh` exec liveness) | New (`tcpSocket`) |
|---|---|---|
| Probe latency under identical CPU starvation | **14,432 ms** → fails 5s budget → kill | **6 ms** → passes |
| Member killed within 95s of starvation? | killed in ~50s (RESTARTS 0→1) | **not killed** (RESTARTS=0) |
| Role during starvation | primary killed → election | **kept PRIMARY** |
| px-backup `server selection timeout` errors | reproduced (8×) | **0** |

## Changes (chart `px-central`)

1. **Liveness probe → `tcpSocket:27017`** — process-liveness only, so it cannot false-fail under starvation and can never restart a healthy primary. The `isWritablePrimary || secondary` role check moves to the **readiness** probe (which only removes the pod from the Service, never restarts it); readiness `timeoutSeconds` widened `5 → 15`.
2. **Container resources** (`values.mongodbResources`) — moves the pods off **BestEffort**. Memory limit (`6Gi`) exceeds the 4 GB WiredTiger cache (`persistentStorage.mongoCacheSize`) so it isn't OOMKilled at the cache ceiling. Stops the starvation and stops the scheduler co-locating heavy workload onto the mongo nodes.
3. **`terminationGracePeriodSeconds: 120`** (`values.mongodbTerminationGracePeriodSeconds`) — lets a SIGTERM'd mongod checkpoint and step down cleanly instead of being SIGKILLed on grace expiry (which caused WiredTiger crash recovery + oplog rollback).
4. **`podAntiAffinity` default `false → true`** (already values-gated in the chart) + a new **PodDisruptionBudget** (`minAvailable: 2`, toggle `values.mongodbPodDisruptionBudget`) — members never co-locate, and voluntary disruption can never drop below quorum.

All new behavior is values-tunable; set `mongodbPodDisruptionBudget: false` / `podAntiAffinity: false` for single-/two-node dev clusters.

## Testing

- `helm lint` and `helm template` pass; rendered output verified for all four changes.
- Live A/B on a px-backup cluster (chart `px-central-3.1.0`): the old exec probe killed the primary under CPU starvation and reproduced the exact px-backup `ReplicaSetNoPrimary` error; after switching liveness to `tcpSocket`, the primary survived identical starvation with 0 restarts and px-backup logged 0 errors. Cluster restored to as-found state afterward.

## Notes / follow-ups (not in this PR)

- The `pxc-backup-mongodb-scripts` ConfigMap (holding `setup.sh`) is **referenced but not created** by this chart — the slow-rejoin fast-path fix belongs wherever that script is generated (px-central operator).
- Optional defense-in-depth: raise px-backup's mongo `serverSelectionTimeout` and add Torpedo retry on transient `server selection timeout`.

## Acceptance criteria (PB-16568)

- ✅ A liveness failure cannot, by itself, kill the current primary — met structurally by (1).
- ✅ Members not restarted/evicted on transient load — (1) + (2) + (3).
- ✅ Replica set retains a primary under the load profile — (2) + (4).

[PB-16568]: https://purestorage.atlassian.net/browse/PB-16568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ